### PR TITLE
Remove unused dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -34,7 +34,7 @@ BEFORE YOU BEGIN
     "libpoppler-cpp-dev(el)" package has to be installed if the
     Poppler packages from a Linux distribution are used).
 
-    Besides these tools you'll want the JPEG, PNG, TIFF, ZLIB, and
+    Besides these tools you'll want the JPEG, PNG, TIFF and
     EXIF libraries for image support. libcupsfilters will compile and
     run without these, however you'll miss out on many of the features
     provided by libcupsfilters.

--- a/INSTALL
+++ b/INSTALL
@@ -26,7 +26,7 @@ BEFORE YOU BEGIN
     programs shipped by Compaq, HP, SGI, and Sun.  BSD users should
     use GNU make (gmake) since BSD make does not support "include".
 
-    Poppler, freetype, fontconfig, liblcms (liblcms2 recommended), and
+    Poppler, fontconfig, liblcms (liblcms2 recommended), and
     QPDF must be installed to be able to compile this package.
 
     Note that Poppler has to be compiled with the

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Applications, like image and raster graphics handling,
 make/model/device ID matching, ...
 
 For compiling and using this package CUPS (2.2.2 or newer),
-libqpdf (10.3.2 or newer), libjpeg, libpng, libtiff, freetype,
-fontconfig, liblcms (liblcms2 recommended) and libdbus are needed.
+libqpdf (10.3.2 or newer), libjpeg, libpng, libtiff, fontconfig,
+liblcms (liblcms2 recommended) and libdbus are needed.
 It is highly recommended, especially if non-PDF printers are used,
 to have at least one of Ghostscript (preferred), Poppler, or MuPDF.
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ make/model/device ID matching, ...
 
 For compiling and using this package CUPS (2.2.2 or newer),
 libqpdf (10.3.2 or newer), libjpeg, libpng, libtiff, freetype,
-fontconfig, liblcms (liblcms2 recommended), libavahi-common,
-libavahi-client, libdbus, and glib are needed. It is highly
-recommended, especially if non-PDF printers are used, to have at
-least one of Ghostscript (preferred), Poppler, or MuPDF.
+fontconfig, liblcms (liblcms2 recommended) libdbus and glib are needed.
+It is highly recommended, especially if non-PDF printers are used,
+to have at least one of Ghostscript (preferred), Poppler, or MuPDF.
 
 It also needs gcc (C compiler), automake, autoconf, autopoint, and
 libtool. On Debian, Ubuntu, and distributions derived from them

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ make/model/device ID matching, ...
 
 For compiling and using this package CUPS (2.2.2 or newer),
 libqpdf (10.3.2 or newer), libjpeg, libpng, libtiff, freetype,
-fontconfig, liblcms (liblcms2 recommended) libdbus and glib are needed.
+fontconfig, liblcms (liblcms2 recommended) and libdbus are needed.
 It is highly recommended, especially if non-PDF printers are used,
 to have at least one of Ghostscript (preferred), Poppler, or MuPDF.
 

--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,6 @@ AS_IF([test x"$lcms2" = "xno"], [
 	PKG_CHECK_MODULES([LCMS], [lcms])
 	AC_DEFINE([USE_LCMS1], [1], [Defines if use lcms1])
 ])
-PKG_CHECK_MODULES([FREETYPE], [freetype2], [AC_DEFINE([HAVE_FREETYPE_H], [1], [Have FreeType2 include files])])
 PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
 PKG_CHECK_MODULES([LIBQPDF], [libqpdf >= 10.3.2])
 

--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,6 @@ AC_CHECK_HEADERS([stdlib.h])
 AC_CHECK_HEADERS([sys/stat.h])
 AC_CHECK_HEADERS([sys/types.h])
 AC_CHECK_HEADERS([unistd.h])
-AC_CHECK_HEADERS([zlib.h])
 AC_CHECK_HEADERS([endian.h])
 AC_CHECK_HEADERS([dirent.h])
 AC_CHECK_HEADERS([sys/ioctl.h])
@@ -271,8 +270,6 @@ AS_IF([test x"$lcms2" = "xno"], [
 ])
 PKG_CHECK_MODULES([FREETYPE], [freetype2], [AC_DEFINE([HAVE_FREETYPE_H], [1], [Have FreeType2 include files])])
 PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
-PKG_CHECK_MODULES([ZLIB], [zlib])
-AC_DEFINE([HAVE_LIBZ], [1], [Define that we use zlib])
 PKG_CHECK_MODULES([LIBQPDF], [libqpdf >= 10.3.2])
 
 # =================

--- a/configure.ac
+++ b/configure.ac
@@ -232,34 +232,6 @@ fi
 AC_SUBST(EXIF_LIBS)
 AC_SUBST(EXIF_CFLAGS)
 
-# ======================
-# Avahi (DNS-SD support)
-# ======================
-AVAHI_LIBS=""
-AVAHI_CFLAGS=""
-
-AC_ARG_ENABLE([avahi],
-	[AS_HELP_STRING([--disable-avahi], [Disable DNS Service Discovery support using Avahi.])],
-	[enable_avahi="$enableval"],
-	[enable_avahi=yes]
-)
-AM_CONDITIONAL([ENABLE_AVAHI], [test "x$enable_avahi" != "xno"])
-
-AC_ARG_WITH(avahi-libs,
-	[AS_HELP_STRING([--with-avahi-libs], [Set directory for Avahi library.])],
-	AVAHI_LIBS="-L$withval $AVAHI_LIBS",)
-AC_ARG_WITH(avahi-includes,
-	[AS_HELP_STRING([--with-avahi-includes], [Set directory for Avahi includes])],
-	AVAHI_CFLAGS="-I$withval $AVAHI_CFLAGS",)
-
-if test "x$enable_avahi" != xno; then
-	PKG_CHECK_MODULES(AVAHI, avahi-client,
-		[AC_DEFINE(HAVE_AVAHI, [1], [Define if you have the avahi library])])
-fi
-
-AC_SUBST(AVAHI_LIBS)
-AC_SUBST(AVAHI_CFLAGS)
-
 # ==========================================
 # Check for various required modules for PDF
 # ==========================================
@@ -465,7 +437,6 @@ Build configuration:
 	exif:            ${enable_exif}
 	png:             ${with_png}
 	tiff:            ${with_tiff}
-	avahi:           ${enable_avahi}
 	dbus:            ${enable_dbus}
 	werror:          ${enable_werror}
 	test-font:       ${with_test_font_path}


### PR DESCRIPTION
Avahi, Glib, Freetype and Zlib are used in other projects or removed as whole.