### PR TITLE
Coverity fixes

### DIFF
--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -879,7 +879,7 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
   banner_t *banner;
   int num_options = 0;
   int ret;
-  FILE *inputfp;
+  FILE *inputfp = NULL;
   FILE *outputfp;
   int tempfd;
   cups_option_t *options = NULL;
@@ -968,6 +968,10 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
   {
     if (log)
       log(ld, CF_LOGLEVEL_ERROR, "cfFilterBannerToPDF: Could not read banner file");
+
+    if (inputfp)
+      fclose(inputfp);
+
     return (1);
   }
 

--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -934,6 +934,7 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
   if (inputfd)
   {
     fclose(inputfp);
+    inputfp = NULL;
     close(inputfd);
   }
   close(tempfd);
@@ -951,7 +952,7 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
 	    "cfFilterBannerToPDF: Unable to open output data stream.");
     }
 
-    if (!inputfd)
+    if (inputfp)
       fclose(inputfp);
 
     return (1);

--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -951,7 +951,9 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
 	    "cfFilterBannerToPDF: Unable to open output data stream.");
     }
 
-    fclose(inputfp);
+    if (!inputfd)
+      fclose(inputfp);
+
     return (1);
   }
 

--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -880,7 +880,7 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
   int num_options = 0;
   int ret;
   FILE *inputfp = NULL;
-  FILE *outputfp;
+  FILE *outputfp = NULL;
   int tempfd;
   cups_option_t *options = NULL;
   char tempfile[1024], buffer[1024];
@@ -971,6 +971,9 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
 
     if (inputfp)
       fclose(inputfp);
+
+    if (outputfp)
+      fclose(outputfp);
 
     return (1);
   }

--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -919,6 +919,8 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
     if (log) log(ld, CF_LOGLEVEL_ERROR,
 		 "cfFilterBannerToPDF: Unable to copy input file: %s",
 		 strerror(errno));
+    if (inputfp)
+      fclose(inputfp);
     return (1);
   }
 

--- a/cupsfilters/catalog.c
+++ b/cupsfilters/catalog.c
@@ -542,6 +542,8 @@ cfCatalogLoad(const char *location,
   int digit;
   int found_in_catalog = 0;
 
+  memset(tmpfile, 0, 1024);
+
   if (location == NULL || (strncasecmp(location, "http:", 5) &&
 			   strncasecmp(location, "https:", 6)))
   {
@@ -771,6 +773,7 @@ cfCatalogLoad(const char *location,
     free(opt_name);
   if (filename == tmpfile)
     unlink(filename);
-  if (found_in_catalog)
-    free((char *)filename);
+  else
+    if (found_in_catalog)
+      free((char *)filename);
 }

--- a/cupsfilters/catalog.c
+++ b/cupsfilters/catalog.c
@@ -178,6 +178,8 @@ cfCatalogSearchDir(const char *dirname, const char *preferredlocale)
   {
     // Check first for an exact match
     catalog = cfCatalogSearchDirLocale(dirname, preferredlocale);
+    if (catalog != NULL)
+      return (catalog);
 
     // Check for language match, with any region
     // Cover both cases, whether locale has region suffix or not

--- a/cupsfilters/filter.c
+++ b/cupsfilters/filter.c
@@ -959,7 +959,7 @@ cfFilterExternal(int inputfd,              // I - File descriptor input stream
                 *msg,                // Filter log message
                 *filter_name;        // Filter name for logging
   char          filter_path[1024];   // Full path of the filter
-  char          **argv,		     // Command line args for filter
+  char          **argv = NULL,		     // Command line args for filter
                 **envp = NULL;       // Environment variables for filter
   int           num_all_options = 0;
   cups_option_t *all_options = NULL;
@@ -1216,6 +1216,12 @@ cfFilterExternal(int inputfd,              // I - File descriptor input stream
     if (log) log(ld, CF_LOGLEVEL_ERROR,
 		 "cfFilterExternal (%s): Could not create pipe for stderr: %s",
 		 filter_name, strerror(errno));
+
+    if (argv[0])
+      free(argv[0]);
+    if (argv)
+      free(argv);
+
     return (1);
   }
 

--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -988,7 +988,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
       if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	  outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	  outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	if (write(outputfd, "RaS2", 4));
+	write(outputfd, "RaS2", 4);
       goto out;
     }
     if (doc_type == GS_DOC_TYPE_UNKNOWN)
@@ -1010,7 +1010,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
 	if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	  if (write(outputfd, "RaS2", 4));
+	  write(outputfd, "RaS2", 4);
 	goto out;
       }
       if (pages < 0)
@@ -1055,7 +1055,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
 	if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	  if (write(outputfd, "RaS2", 4));
+	  write(outputfd, "RaS2", 4);
 	goto out;
       }
       if (pagecount < 0)

--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -988,7 +988,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
       if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	  outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	  outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	write(outputfd, "RaS2", 4);
+	bytes = write(outputfd, "RaS2", 4);
       goto out;
     }
     if (doc_type == GS_DOC_TYPE_UNKNOWN)
@@ -1010,7 +1010,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
 	if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	  write(outputfd, "RaS2", 4);
+	  bytes = write(outputfd, "RaS2", 4);
 	goto out;
       }
       if (pages < 0)
@@ -1055,7 +1055,7 @@ cfFilterGhostscript(int inputfd,            // I - File descriptor input
 	if (outformat == CF_FILTER_OUT_FORMAT_CUPS_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_PWG_RASTER ||
 	    outformat == CF_FILTER_OUT_FORMAT_APPLE_RASTER)
-	  write(outputfd, "RaS2", 4);
+	  bytes = write(outputfd, "RaS2", 4);
 	goto out;
       }
       if (pagecount < 0)

--- a/cupsfilters/image-zoom.c
+++ b/cupsfilters/image-zoom.c
@@ -42,6 +42,7 @@ _cfImageZoomDelete(cf_izoom_t *z)	// I - Zoom record to free
   free(z->rows[0]);
   free(z->rows[1]);
   free(z->in);
+  cfImageClose(z->img);
   free(z);
 }
 

--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -365,7 +365,7 @@ cfImageOpenFP(
   // Allocate memory...
   //
 
-  img = calloc(sizeof(cf_image_t), 1);
+  img = calloc(1, sizeof(cf_image_t));
 
   if (img == NULL)
   {
@@ -634,7 +634,7 @@ cfImageCrop(cf_image_t* img,
 	    int height)
 {
   int image_width = cfImageGetWidth(img);
-  cf_image_t* temp = calloc(sizeof(cf_image_t), 1);
+  cf_image_t* temp = calloc(1, sizeof(cf_image_t));
   cf_ib_t *pixels = (cf_ib_t*)malloc(img->xsize * cfImageGetDepth(img));
 
   temp->cachefile = -1;
@@ -750,10 +750,10 @@ get_tile(cf_image_t *img,		// I - Image
 
     DEBUG_printf(("Creating tile array (%dx%d)\n", xtiles, ytiles));
 
-    if ((img->tiles = calloc(sizeof(cf_itile_t *), ytiles)) == NULL)
+    if ((img->tiles = calloc(ytiles, sizeof(cf_itile_t *))) == NULL)
       return (NULL);
 
-    if ((tile = calloc(xtiles * sizeof(cf_itile_t), ytiles)) == NULL)
+    if ((tile = calloc(ytiles, xtiles * sizeof(cf_itile_t))) == NULL)
       return (NULL);
 
     for (tiley = 0; tiley < ytiles; tiley ++)
@@ -775,8 +775,8 @@ get_tile(cf_image_t *img,		// I - Image
   {
     if (img->num_ics < img->max_ics)
     {
-      if ((ic = calloc(sizeof(cf_ic_t) +
-                       bpp * CF_TILE_SIZE * CF_TILE_SIZE, 1)) == NULL)
+      if ((ic = calloc(1, sizeof(cf_ic_t) +
+                       bpp * CF_TILE_SIZE * CF_TILE_SIZE)) == NULL)
       {
         if (img->num_ics == 0)
 	  return (NULL);

--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -940,6 +940,8 @@ _cfImageReadEXIF(cf_image_t *img,
   if (buf == NULL || bufSize <= 0 ||
       (ed = exif_data_new_from_data(buf, bufSize)) == NULL)
   {
+    if (buf)
+      free(buf);
     DEBUG_printf(("DEBUG: No EXIF data found"));
     return (2);
   }
@@ -954,6 +956,8 @@ _cfImageReadEXIF(cf_image_t *img,
 
   if (entryX == NULL || entryY == NULL)
   {
+    if (buf)
+      free(buf);
     DEBUG_printf(("DEBUG: No EXIF data found"));
     return (2);
   }

--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -748,6 +748,16 @@ get_tile(cf_image_t *img,		// I - Image
     xtiles = (img->xsize + CF_TILE_SIZE - 1) / CF_TILE_SIZE;
     ytiles = (img->ysize + CF_TILE_SIZE - 1) / CF_TILE_SIZE;
 
+   /*
+    * We check the image validity (f.e. whether xsize and ysize are
+    * greater than 0) during opening the file, but it happens several
+    * functions before and reader can miss it. Add the check for stressing
+    * out such cases are not accepted, which adds readability and fixes
+    * false positives of coverity programs.
+    */
+    if (xtiles <= 0 || ytiles <= 0)
+      return (NULL);
+
     DEBUG_printf(("Creating tile array (%dx%d)\n", xtiles, ytiles));
 
     if ((img->tiles = calloc(ytiles, sizeof(cf_itile_t *))) == NULL)

--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -409,7 +409,7 @@ cfImageOpenFP(
 
   if (status)
   {
-    free(img);
+    cfImageClose(img);
     return (NULL);
   }
   else

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -1647,7 +1647,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 
 	  xtemp = header.HWResolution[0] * xprint;
 	  ytemp = header.HWResolution[1] * yprint;
-        }
+	}
 
         cupsRasterWriteHeader2(ras, &header);
 
@@ -1657,10 +1657,10 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	  // Initialize the image "zoom" engine...
 	  //
 
-          if (doc.Flip)
+	  if (doc.Flip)
 	    z = _cfImageZoomNew(img, xc0, yc0, xc1, yc1, -xtemp, ytemp,
 	                          doc.Orientation & 1, zoom_type);
-          else
+	  else
 	    z = _cfImageZoomNew(img, xc0, yc0, xc1, yc1, xtemp, ytemp,
 	                          doc.Orientation & 1, zoom_type);
 
@@ -1668,7 +1668,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	  // Write leading blank space as needed...
 	  //
 
-          if (header.cupsHeight > z->ysize && doc.YPosition <= 0)
+	  if (header.cupsHeight > z->ysize && doc.YPosition <= 0)
 	  {
 	    blank_line(&header, row);
 

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -1685,8 +1685,10 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	      if (cupsRasterWritePixels(ras, row, header.cupsBytesPerLine) <
 	              header.cupsBytesPerLine)
 	      {
-		if (log) log(ld, CF_LOGLEVEL_ERROR,
-			     "cfFilterImageToRaster: Unable to send raster data.");
+		if (log)
+		  log(ld, CF_LOGLEVEL_ERROR, "cfFilterImageToRaster: Unable to send raster data.");
+		if (z)
+		  _cfImageZoomDelete(z);
 		cfImageClose(img);
 		return (1);
 	      }
@@ -1787,6 +1789,8 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	      if (log) log(ld, CF_LOGLEVEL_DEBUG,
 			   "cfFilterImageToRaster: Unable to send raster data.");
 	      cfImageClose(img);
+	      if (z)
+		_cfImageZoomDelete(z);
 	      return (1);
 	    }
 

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -1687,8 +1687,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	      {
 		if (log)
 		  log(ld, CF_LOGLEVEL_ERROR, "cfFilterImageToRaster: Unable to send raster data.");
-		if (z)
-		  _cfImageZoomDelete(z);
+		_cfImageZoomDelete(z);
 		cfImageClose(img);
 		return (1);
 	      }
@@ -1789,8 +1788,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 	      if (log) log(ld, CF_LOGLEVEL_DEBUG,
 			   "cfFilterImageToRaster: Unable to send raster data.");
 	      cfImageClose(img);
-	      if (z)
-		_cfImageZoomDelete(z);
+	      _cfImageZoomDelete(z);
 	      return (1);
 	    }
 
@@ -1833,6 +1831,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 		if (log) log(ld, CF_LOGLEVEL_ERROR,
 			     "cfFilterImageToRaster: Unable to send raster data.");
 		cfImageClose(img);
+		_cfImageZoomDelete(z);
 		return (1);
 	      }
             }

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -235,7 +235,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
   int			plane,		// Current color plane
 			num_planes;	// Number of color planes
   char			tempfile[1024];	// Name of temporary file
-  FILE                  *fp;		// Input file
+  FILE                  *fp = NULL;		// Input file
   int                   fd;		// File descriptor for temp file
   char                  buf[BUFSIZ];
   int                   bytes;
@@ -705,11 +705,13 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
     case CUPS_CSPACE_DEVICED :
     case CUPS_CSPACE_DEVICEE :
     case CUPS_CSPACE_DEVICEF :
-        if (log) log(ld, CF_LOGLEVEL_DEBUG,
-		     "cfFilterImageToRaster: Colorspace %d not supported.",
-		     header.cupsColorSpace);
+	if (log)
+	  log(ld, CF_LOGLEVEL_DEBUG, "cfFilterImageToRaster: Colorspace %d not supported.",
+	      header.cupsColorSpace);
 	if (!inputseekable)
 	  unlink(tempfile);
+	if (fp)
+	  fclose(fp);
 	return(1);
 	break;
   }

--- a/cupsfilters/pclmtoraster.cxx
+++ b/cupsfilters/pclmtoraster.cxx
@@ -63,11 +63,11 @@ typedef unsigned char *(*convert_line_func)(unsigned char *src,
 					    pclmtoraster_data_t *data,
 					    convert_cspace_func convertcspace);
 
-typedef struct conversion_function_s
+typedef struct pclm_conversion_function_s
 {
   convert_cspace_func convertcspace;// Function for conversion of colorspaces
   convert_line_func convertline;    // Function tom modify raster data of a line
-} conversion_function_t;
+} pclm_conversion_function_t;
 
 
 static int
@@ -688,7 +688,7 @@ select_convert_func(int			pgno,	 // I - Page number
 						 //     function
 		    pclmtoraster_data_t	*data,	 // I - pclmtoraster filter
 						 //     data
-		    conversion_function_t *convert)// I - Conversion function
+		    pclm_conversion_function_t *convert)// I - Conversion function
 {
   // Set rowsize and numcolors based on colorspace of raster data
   cups_page_header2_t header = data->header;
@@ -792,7 +792,7 @@ out_page(cups_raster_t*	 raster, 	// I - Raster stream
 	 void*		 ld,		// I - Aux. data for log function
 	 pclmtoraster_data_t *data,	// I - pclmtoraster filter data
 	 cf_filter_data_t *filter_data,	// I - filter data
-	 conversion_function_t *convert)// I - Conversion functions
+	 pclm_conversion_function_t *convert)// I - Conversion functions
 {
   int                   i;
   long long		rotate = 0,
@@ -1077,7 +1077,7 @@ cfFilterPCLmToRaster(int inputfd,         // I - File descriptor input stream
   QPDF			*pdf = new QPDF();
   cups_raster_t		*raster;
   pclmtoraster_data_t	pclmtoraster_data;
-  conversion_function_t convert;
+  pclm_conversion_function_t convert;
   cf_logfunc_t		log = data->logfunc;
   void			*ld = data->logdata;
   cf_filter_iscanceledfunc_t iscanceled = data->iscanceledfunc;

--- a/cupsfilters/pclmtoraster.cxx
+++ b/cupsfilters/pclmtoraster.cxx
@@ -164,7 +164,8 @@ parse_opts(cf_filter_data_t *data,
                            !strncasecmp(val, "bi-level", 8))
     pclmtoraster_data->bi_level = 1;
 
-  strncpy(pclmtoraster_data->pageSizeRequested, header->cupsPageSizeName, 64);
+  strncpy(pclmtoraster_data->pageSizeRequested, header->cupsPageSizeName, 63);
+  pclmtoraster_data->pageSizeRequested[63] = '\0';
   if (log) log(ld, CF_LOGLEVEL_DEBUG,
 		"cfFilterPCLmToRaster: Page size requested: %s.",
 	       header->cupsPageSizeName);

--- a/cupsfilters/pdftoraster.cxx
+++ b/cupsfilters/pdftoraster.cxx
@@ -1459,6 +1459,8 @@ write_page_image(cups_raster_t *raster,
 					       doc->bytesPerLine * im.height());
 	  one_bit_pixel(graydata, onebitdata, im.width(), im.height(), doc);
 	  colordata = onebitdata;
+	  free(newdata);
+	  free(graydata);
 	  rowsize = doc->bytesPerLine;
 	}
 	else
@@ -1476,6 +1478,7 @@ write_page_image(cups_raster_t *raster,
 	  cfImageRGBToWhite(newdata, graydata, pixel_count);
 	  colordata = graydata;
 	  rowsize = doc->header.cupsWidth;
+	  free(newdata);
 	}
 
 	break;

--- a/cupsfilters/pdftoraster.cxx
+++ b/cupsfilters/pdftoraster.cxx
@@ -133,13 +133,13 @@ typedef unsigned char *(*convert_line_func)(unsigned char *src,
 					    pdftoraster_doc_t* doc,
 					    convert_cspace_func convertCSpace);
 
-typedef struct conversion_function_s
+typedef struct pdf_conversion_function_s
 {
   convert_cspace_func convertCSpace; // Function for conversion of colorspaces
   convert_line_func convertLineOdd;  // Function tom modify raster data of a
                                      // line
   convert_line_func convertLineEven;
-} conversion_function_t;
+} pdf_conversion_function_t;
 
 
 static cmsCIExyY adobergb_wp()
@@ -1081,7 +1081,7 @@ convert_line_plane_swap(unsigned char *src,
 // Handle special cases which appear in the Gutenprint driver
 static bool
 select_special_case(pdftoraster_doc_t* doc,
-		    conversion_function_t* convert)
+		    pdf_conversion_function_t* convert)
 {
   int i;
 
@@ -1172,7 +1172,7 @@ get_cms_color_space_type(cmsColorSpaceSignature cs)
 static int
 select_convert_func(cups_raster_t *raster,
 		    pdftoraster_doc_t* doc,
-		    conversion_function_t *convert,
+		    pdf_conversion_function_t *convert,
 		    cf_logfunc_t log,
 		    void* ld)
 {
@@ -1401,7 +1401,7 @@ static void
 write_page_image(cups_raster_t *raster,
 		 pdftoraster_doc_t *doc,
 		 int pageNo,
-		 conversion_function_t* convert,
+		 pdf_conversion_function_t* convert,
 		 float overspray_factor,
 		 cf_filter_iscanceledfunc_t iscanceled,
 		 void *icd)
@@ -1554,7 +1554,7 @@ out_page(pdftoraster_doc_t *doc,
 	 int pageNo,
 	 cf_filter_data_t *data,
 	 cups_raster_t *raster,
-	 conversion_function_t *convert,
+	 pdf_conversion_function_t *convert,
 	 cf_logfunc_t log,
 	 void* ld,
 	 cf_filter_iscanceledfunc_t iscanceled,
@@ -1914,7 +1914,7 @@ cfFilterPDFToRaster(int inputfd,            // I - File descriptor input stream
 #ifdef HAVE_POPPLER
   int                        deviceCopies = 1;
   bool                       deviceCollate = false;
-  conversion_function_t      convert;
+  pdf_conversion_function_t      convert;
   cf_filter_iscanceledfunc_t iscanceled = data->iscanceledfunc;
   void                       *icd = data->iscanceleddata;
   int                        ret = 0;
@@ -2149,7 +2149,7 @@ cfFilterPDFToRaster(int inputfd,            // I - File descriptor input stream
     ret = 1;
     goto out;
   }
-  memset(&convert, 0, sizeof(conversion_function_t));
+  memset(&convert, 0, sizeof(pdf_conversion_function_t));
   if (select_convert_func(raster, &doc, &convert, log, ld) == 1)
   {
     if (log) log(ld, CF_LOGLEVEL_ERROR,

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -739,7 +739,8 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
     // The page size name in te header corresponds to the actual size of
     // the media, so find the size dimensions
     pwg_media_t *size_found = NULL;
-    strncpy(keyword, doc.h.cupsPageSizeName, sizeof(keyword));
+    strncpy(keyword, doc.h.cupsPageSizeName, sizeof(keyword) - 1);
+    keyword[sizeof(keyword) - 1] = '\0';
     if ((keyptr = strchr(keyword, '.')) != NULL)
       *keyptr = '\0';
     if ((size_found = pwgMediaForPPD(keyword)) != NULL ||

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -864,7 +864,7 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
     goto out;
   }
 
-  doc.Page    = calloc(sizeof(lchar_t *), doc.SizeLines);
+  doc.Page    = calloc(doc.SizeLines, sizeof(lchar_t *));
   if (!doc.Page)
   {
     if (log) log(ld, CF_LOGLEVEL_ERROR,
@@ -873,7 +873,7 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
     goto out;
   }
 
-  doc.Page[0] = calloc(sizeof(lchar_t), doc.SizeColumns * doc.SizeLines);
+  doc.Page[0] = calloc(doc.SizeColumns * doc.SizeLines, sizeof(lchar_t));
   if (!doc.Page[0])
   {
     free(doc.Page);

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -877,7 +877,6 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
   doc.Page[0] = calloc(doc.SizeColumns * doc.SizeLines, sizeof(lchar_t));
   if (!doc.Page[0])
   {
-    free(doc.Page);
     if (log) log(ld, CF_LOGLEVEL_ERROR,
 		 "cfFilterTextToPDF: cannot allocate memory for page");
     ret = 1;
@@ -1434,7 +1433,8 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
 
   if (doc.Page)
   {
-    free(doc.Page[0]);
+    if (doc.Page[0])
+      free(doc.Page[0]);
     free(doc.Page);
   }
 

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -1963,6 +1963,7 @@ write_prolog(const char *title,		// I - Title of job
 
 	  if (log) log(ld, CF_LOGLEVEL_ERROR,
 		       "cfFilterTextToPDF: Bad font description line: %s", valptr);
+	  fclose(fp);
 	  return (1);
 	}
 
@@ -1976,6 +1977,7 @@ write_prolog(const char *title,		// I - Title of job
 	{
 	  if (log) log(ld, CF_LOGLEVEL_ERROR,
 		       "cfFilterTextToPDF: Bad text direction %s", valptr);
+	  fclose(fp);
 	  return (1);
 	}
 
@@ -1999,6 +2001,7 @@ write_prolog(const char *title,		// I - Title of job
 
 	  if (log) log(ld, CF_LOGLEVEL_ERROR,
 		       "cfFilterTextToPDF: Bad font description line: %s", valptr);
+	  fclose(fp);
 	  return (1);
 	}
 
@@ -2012,6 +2015,7 @@ write_prolog(const char *title,		// I - Title of job
 	{
 	  if (log) log(ld, CF_LOGLEVEL_ERROR,
 		       "cfFilterTextToPDF: Bad text width %s", valptr);
+	  fclose(fp);
 	  return (1);
 	}
 
@@ -2090,6 +2094,7 @@ write_prolog(const char *title,		// I - Title of job
     {
       if (log) log(ld, CF_LOGLEVEL_ERROR,
 		   "cfFilterTextToPDF: Bad charset type %s", lineptr);
+      fclose(fp);
       return (1);
     } // }}}
   } // }}}

--- a/cupsfilters/texttotext.c
+++ b/cupsfilters/texttotext.c
@@ -1100,6 +1100,8 @@ cfFilterTextToText(int inputfd,         // I - File descriptor input stream
   if (iconv_close (cd) != 0)
     if (log) log(ld, CF_LOGLEVEL_DEBUG,
 		 "cfFilterTextToText: Error closing iconv encoding conversion session");
+  else
+    cd = (iconv_t) -1;
 
   // Error out on an illegal UTF-8 sequence in the input file
   if (result < 0)
@@ -1141,6 +1143,9 @@ cfFilterTextToText(int inputfd,         // I - File descriptor input stream
 
   free(page_ranges);
   free(out_page);
+
+  if (cd != (iconv_t) -1)
+    iconv_close(cd);
 
   return (exit_status);
 }

--- a/cupsfilters/texttotext.c
+++ b/cupsfilters/texttotext.c
@@ -1098,8 +1098,10 @@ cfFilterTextToText(int inputfd,         // I - File descriptor input stream
   close(fd);
   
   if (iconv_close (cd) != 0)
+  {
     if (log)
       log(ld, CF_LOGLEVEL_DEBUG, "cfFilterTextToText: Error closing iconv encoding conversion session");
+  }
   else
     cd = (iconv_t) -1;
 

--- a/cupsfilters/texttotext.c
+++ b/cupsfilters/texttotext.c
@@ -1098,8 +1098,8 @@ cfFilterTextToText(int inputfd,         // I - File descriptor input stream
   close(fd);
   
   if (iconv_close (cd) != 0)
-    if (log) log(ld, CF_LOGLEVEL_DEBUG,
-		 "cfFilterTextToText: Error closing iconv encoding conversion session");
+    if (log)
+      log(ld, CF_LOGLEVEL_DEBUG, "cfFilterTextToText: Error closing iconv encoding conversion session");
   else
     cd = (iconv_t) -1;
 


### PR DESCRIPTION
Hi Till,

I've run our internal Coverity software (which is aggregator of open source checks as cppcheck, clang etc and proprietary coverity) on libcupsfilters as part of getting new projects into Fedora and found several issues which Coverity team marks as important to fix (such as use after free, leaks, double free etc) - the list is [here](https://github.com/OpenPrinting/libcupsfilters/files/10721597/covscan-important-issues.txt).

There are fixes for the reported issues, some indenting changes and incorrect use of calloc (args were switched) - I left the commits as they are to visibility which fix belongs to which issue.