### PR TITLE
replaced PointerHolder with shared_ptr

### DIFF
--- a/cupsfilters/pclmtoraster.cxx
+++ b/cupsfilters/pclmtoraster.cxx
@@ -939,7 +939,7 @@ out_page(cups_raster_t*	 raster, 	// I - Raster stream
     image = iter.second;
     imgdict = image.getDict(); // XObject dictionary
 
-    PointerHolder<Buffer> actual_data = image.getStreamData(qpdf_dl_all);
+    std::shared_ptr<Buffer> actual_data = image.getStreamData(qpdf_dl_all);
     width = imgdict.getKey("/Width").getIntValue();
     height = imgdict.getKey("/Height").getIntValue();
     colorspace_obj = imgdict.getKey("/ColorSpace");

--- a/cupsfilters/pdf.cxx
+++ b/cupsfilters/pdf.cxx
@@ -169,7 +169,7 @@ cfPDFPrependStream(cf_pdf_t *pdf,      // I - Pointer to QPDF object
     return (1);
 
   // prepare the new stream which is to be prepended
-  PointerHolder<Buffer> stream_data = PointerHolder<Buffer>(new Buffer(len));
+  std::shared_ptr<Buffer> stream_data = std::shared_ptr<Buffer>(new Buffer(len));
   memcpy(stream_data->getBuffer(), buf, len);
   QPDFObjectHandle stream = QPDFObjectHandle::newStream(pdf, stream_data);
   stream = pdf->makeIndirectObject(stream);

--- a/cupsfilters/pdftopdf/qpdf-xobject.cxx
+++ b/cupsfilters/pdftopdf/qpdf-xobject.cxx
@@ -159,7 +159,7 @@ _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
   std::vector<QPDFObjectHandle> contents = page.getPageContents();
                                                   // (will assertPageObject)
 
-  auto ph = PointerHolder<QPDFObjectHandle::StreamDataProvider>(new CombineFromContents_Provider(contents));
+  auto ph = std::shared_ptr<QPDFObjectHandle::StreamDataProvider>(new CombineFromContents_Provider(contents));
   ret.replaceStreamData(ph, filter, decode_parms);
 
   return (ret);


### PR DESCRIPTION
PointerHolder is deprecated in the qpdf v11, getting replaced with std::shared_ptr. Warnings should be fixed with qpdf v12 onwards.