### PR TITLE
Update imagetoraster.c

### DIFF
--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -1852,7 +1852,7 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
  canceled:
   free(row);
   cupsRasterClose(ras);
-  cfImageClose(img);
+  //cfImageClose(img); 
   close(outputfd);
 
   return (0);


### PR DESCRIPTION
Commenting out excessive delete. This resolves the error.
This is with respect to issue https://github.com/OpenPrinting/cups-filters/issues/507. 