### PR TITLE
Update doc->orientation value in imagetopdf.c file

### DIFF
--- a/cupsfilters/imagetopdf.c
+++ b/cupsfilters/imagetopdf.c
@@ -963,6 +963,7 @@ cfFilterImageToPDF(int inputfd,         // I - File descriptor input stream
     }
     if (tempOrientation == 4 || tempOrientation == 5)
     {
+      doc.Orientation=1;
       int tmp = pw;
       pw = ph;
       ph = tmp;
@@ -1059,6 +1060,7 @@ cfFilterImageToPDF(int inputfd,         // I - File descriptor input stream
     {
       if (tempOrientation == 4 || tempOrientation == 5)
       {
+	doc.Orientation=1;
         float temp = pw;
         pw = ph;
         ph = temp;


### PR DESCRIPTION
value of doc->orientation not set when landscape mode is true. Due to this the final output have portrait orientation always no matter if the value of landscape is true. 
@tillkamppeter sir can you please review it.
Thank you.