### PR TITLE
universal.c: Support application/vnd.cups-postscript

### DIFF
--- a/cupsfilters/universal.c
+++ b/cupsfilters/universal.c
@@ -152,7 +152,7 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
   else
   {
 #ifdef HAVE_GHOSTSCRIPT
-    if (!strcasecmp(input, "application/postscript"))
+    if (!strcasecmp(input, "application/postscript") || !strcasecmp(input, "application/vnd.cups-postscript"))
     {
       outformat = malloc(sizeof(cf_filter_out_format_t));
       *outformat = CF_FILTER_OUT_FORMAT_PDF;


### PR DESCRIPTION
Some filters (like hpps from hplip) produce this MIME type, so if the client uses classic driver/printer app and the server IPP Everywhere, job fail because the library is not able to find suitable conversion.

This patch together with cups-filters PR fixes the issue.