### PR TITLE
raster.c: Fix build after last fix

### DIFF
--- a/cupsfilters/raster.c
+++ b/cupsfilters/raster.c
@@ -29,6 +29,7 @@
 #include <cupsfilters/ipp.h>
 #include <cupsfilters/libcups2-private.h>
 #include <cups/pwg.h>
+#include <stdbool.h>
 
 //
 // Local functions


### PR DESCRIPTION
Add header file `stdbool`, since we started to use `bool` in `raster_base_header()`.