### PR TITLE
raster.c: Use sRGB if driver is pwg/urf and has ColorModel option

### DIFF
--- a/cupsfilters/raster.c
+++ b/cupsfilters/raster.c
@@ -1550,7 +1550,7 @@ raster_base_header(cups_page_header_t *h,  // O - Raster header
     {
       if (*(val + 4) == '_' || *(val + 4) == '-')
 	ptr = val + 5;
-      colorspace = 18;
+      colorspace = pwg_raster ? 18 : 3;
       numcolors = 1;
     }
     else if (is_color && !strncasecmp(val, "Srgb", 4))

--- a/cupsfilters/raster.c
+++ b/cupsfilters/raster.c
@@ -1571,7 +1571,7 @@ raster_base_header(cups_page_header_t *h,  // O - Raster header
     {
       if (*(val + 3) == '_' || *(val + 3) == '-')
 	ptr = val + 4;
-      colorspace = 1;
+      colorspace = pwg_raster ? 19 : 1;
       numcolors = 3;
     }
     else if (!strcasecmp(val, "auto"))


### PR DESCRIPTION
Some driverless printers (EPSON L3160 in Fedora report) stopped working after commit c6175a2 if `ColorModel=RGB` is passed as option. A different CUPS color space is assigned with the fix - CUPS_CSPACE_RGB, which results in no ICC profile being assigned into Ghostscript command line.

Probably we can try other .icc profiles with CUPS_CSPACE_RGB (srgb.icc does not work with RGB color space), but I tested with reporter that using sRGB space + srgb.icc works for the printer - so the patch is to use sRGB if the driver is URF/PWG.