### PR TITLE
Fix content data stream concatenation mangling output in cfFilterPDFToPDF

### DIFF
--- a/cupsfilters/pdftopdf/qpdf-xobject.cxx
+++ b/cupsfilters/pdftopdf/qpdf-xobject.cxx
@@ -38,7 +38,8 @@ CombineFromContents_Provider::provideStreamData(int objid,
 {
   Pl_Concatenate concat("concat", pipeline);
   const int clen = contents.size();
-  for (int iA = 0; iA < clen; iA ++) {
+  for (int iA = 0; iA < clen; iA ++)
+  {
     contents[iA].pipeStreamData(&concat, true, false, false);
     concat << "\n";
   }

--- a/cupsfilters/pdftopdf/qpdf-xobject.cxx
+++ b/cupsfilters/pdftopdf/qpdf-xobject.cxx
@@ -38,8 +38,10 @@ CombineFromContents_Provider::provideStreamData(int objid,
 {
   Pl_Concatenate concat("concat", pipeline);
   const int clen = contents.size();
-  for (int iA = 0; iA < clen; iA ++)
+  for (int iA = 0; iA < clen; iA ++) {
     contents[iA].pipeStreamData(&concat, true, false, false);
+    concat << "\n";
+  }
   concat.manualFinish();
 }
 


### PR DESCRIPTION
When running the following command on [example.pdf](https://drive.google.com/file/d/10JomuzeZc-3WvSaKo0gIbBftj9V4Glro/view?usp=drive_link)
`./pdftopdf 1 1 1 1 "" example.pdf > output.pdf`

the resultant [output.pdf](https://drive.google.com/file/d/1uSo_CYob2mx6M3LqXITey7IMLoKfXlZd/view?usp=drive_link) is mangled.

This is better explained in [this bug report](https://github.com/OpenPrinting/cups-filters/issues/549).

It seems that the logic that provides the content data streams and concatenates them to form a single stream in an XObject is assuming a correct separation between the contents of successive streams.
To better illustrate: in example.pdf above (note that the sample pdf's have been run through `qpdf --qdf --recompress-flate --compress-streams=n --object-streams=disable` for illustration purposes), page 1's contents are
```
 /Contents [9 0 R 11 0 R 13 0 R 15 0 R]                                                                                                                                           
```

and looking at objects 9-11:
```
%% Contents for page 1
%% object 9
9 0 obj
<</Length 10 0 R>>
stream
q
endstream
endobj

%% object 10
10 0 obj
1
endobj

%% object 11
11 0 obj
<</Length 12 0 R>>
stream
q 0.1 0 0 0.1 0 0 cm
%% only the beginning of object 11 shown
```

This results in the following in output.pdf above:
```
%% resultant XObject. irrelevant info excluded
11 0 obj
<</Subtype /Form /Type /XObject /Length 12 0 R>>
stream
qq 0.1 0 0 0.1 0 0 cm
```

so the concatenation of streams 9 and 11 result in the (invalid) command 'qq', confusing pdf parsers and mangling the output.

With the patch applied, the output becomes

```
%% resultant XObject. irrelevant info excluded
11 0 obj
<</Subtype /Form /Type /XObject /Length 12 0 R>>
stream
q
q 0.1 0 0 0.1 0 0 cm
```

I'm not sure if this is the best solution for the problem, but hopefully the analysis can at least point to that.