### PR TITLE
pkgconfig: Add '-I${includedir}' to Cflags

### DIFF
--- a/libcupsfilters.pc.in
+++ b/libcupsfilters.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 
 Libs: -L${libdir} -lcupsfilters
 Libs.private: @CUPS_LIBS@ @LIBJPEG_LIBS@ @LIBPNG_LIBS@ @LIBTIFF_LIBS@ @LIBQPDF_LIBS@
-Cflags: -I${includedir}/cupsfilters
+Cflags: -I${includedir}/cupsfilters -I${includedir}


### PR DESCRIPTION
Don't just specify `-I${includedir}/cupsfilters`,
but also `-I${includedir}` in the Cflags
in the pkgconfig file.

This way, includes prefixed with the "cupsfilters/" directory path also work.

This e.g. makes the libppd build work when
libcupsfilters is installed in a non-default path
(e.g. configured with `--prefix=$HOME/temp/cpdb`)
and libppd is configured to use that one
(e.g. by setting env variable
`PKG_CONFIG_PATH=$HOME/temp/cpdb/lib/pkgconfig/`
during configure).

Without this commit, libppd's configure would
succeed in the above scenario, but the actual build using `make` would then fail to find the cupsfilters headers:

    make  all-recursive
    make[1]: Entering directory '/home/michi/development/git/libppd'
    make[2]: Entering directory '/home/michi/development/git/libppd'
      CC       ppd/libppd_la-ppd-attr.lo
    In file included from ppd/ppd-attr.c:16:
    ./ppd/ppd.h:26:12: fatal error: cupsfilters/log.h: No such file or directory
       26 | #  include <cupsfilters/log.h>
          |            ^~~~~~~~~~~~~~~~~~~
    compilation terminated.

(This is with libppd [1] git master as of commit
327b61cf5ec3bc74677e3b56fde4c8c4e9acdcb7).

[1] https://github.com/OpenPrinting/libppd