### PR TITLE
Revise building docs and add testing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ test-ps
 testfilters
 test-analyze
 Test_summary_final.txt
+test.pdf
+test.ps

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,6 +77,11 @@ or
 - libcupsfilters is supported for CUPS from version 2.2.2.
 - For earlier CUPS versions (1.5.x, required since 1.6.x), use cups-filters 1.x.
 
+## Testing
+- For CI testing and build checks, run with:
+```
+make check
+```
 
 ## Installing Required Tools
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,9 +85,9 @@ or
   ```
   sudo apt-get install build-essential autoconf autopoint automake libtool
   ```
-- Install Poppler, fontconfig, liblcms2, mupdf-tools:
+- Install Poppler, fontconfig, liblcms2, mupdf-tools, gettext, libcups2-dev, libqpdf-dev:
   ```
-  sudo apt-get install libpoppler-cpp-dev poppler-utils libfontconfig1-dev liblcms2-dev mupdf-tools
+  sudo apt-get install libpoppler-cpp-dev poppler-utils libfontconfig1-dev liblcms2-dev mupdf-tools gettext libcups2-dev libqpdf-dev
   ```
 - Install Ghostscript (for non-PDF printers):
   ```


### PR DESCRIPTION
1. Add missing dependencies for building the project
2. Add testing instructions 
3. Ignore tmp files generated during testing