### PR TITLE
Use /bin/sh for testfilters.sh to avoid dependency on bash

### DIFF
--- a/cupsfilters/testfilters.sh
+++ b/cupsfilters/testfilters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Test-Suite for Libcupsfilters"
 #Now run the executable file with test case


### PR DESCRIPTION
The script is so simple that every shell should support it. This allows building libcupsfilters without bash installed again.