### PR TITLE
pdftopdf: do not generate extra blank page for page-set=even

### DIFF
--- a/cupsfilters/pdftopdf/pdftopdf-processor.cxx
+++ b/cupsfilters/pdftopdf/pdftopdf-processor.cxx
@@ -414,7 +414,7 @@ _cfProcessPDFToPDF(_cfPDFToPDFProcessor &proc,
     bool newPage = nupstate.mext_page(rect.width, rect.height, pgedit);
     if (newPage)
     {
-      if ((curpage) && (param.with_page(outputpage)))
+      if (curpage && (param.with_page(outputpage) || (numOrigPages == 1 && !param.odd_pages)))
       {
 	curpage->rotate(param.orientation);
 	if (param.mirror)
@@ -479,7 +479,7 @@ _cfProcessPDFToPDF(_cfPDFToPDFProcessor &proc,
 
     //pgedit.dump(doc);
   }
-  if ((curpage) && (param.with_page(outputpage)))
+  if (curpage && (param.with_page(outputpage) || (numOrigPages == 1 && !param.odd_pages)))
   {
     curpage->rotate(param.orientation);
     if (param.mirror)
@@ -493,7 +493,7 @@ _cfProcessPDFToPDF(_cfPDFToPDFProcessor &proc,
 				     param.copies_to_be_logged);
   }
 
-  if ((param.even_duplex || !param.odd_pages) && (outputno & 1))
+  if (param.even_duplex && (outputno & 1))
   {
     // need to output empty page to not confuse duplex
     proc.add_page(proc.new_page(param.page.width,


### PR DESCRIPTION
Since [commit 686a28d][2] pdftopdf started to insert extra blank page when printing even-paged documents in page-set=even mode. This was the attempt to fix two issues at once:

* [Print 1-page documents in even mode][1]
* Treat non-duplex even reverse printing as second step of manual duplex

Unfortunately due to inverted logic this didn't fix any issues and introduced new one, outlined above.

This code fixes printing 1-page documents in even mode, and prints exactly what the user requested in even mode for larger documents, without inserting extra blank pages.

[cups-filters issue #541][3]

[1]: https://bugs.launchpad.net/ubuntu/+source/cups-filters/+bug/1340435
[2]: https://github.com/OpenPrinting/cups-filters/commit/686a28d8660f1c95f203fae7f275452b89f91761
[3]: https://github.com/OpenPrinting/cups-filters/issues/541