### PR TITLE
Fix transferring error exit status from children (Issue #76)

### DIFF
--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -699,6 +699,13 @@ gs_spawn (const char *filename,
   if (log) log(ld, CF_LOGLEVEL_DEBUG,
 	       "cfFilterGhostscript: Input data feed completed");
 
+  //
+  // Initialize to exit status 'Success' first - any error exit status
+  // from children process will rewrite it, and wait for children...
+  //
+
+  status = 0;
+
   while (gspid > 0 || errpid > 0)
   {
     if ((pid = wait(&wstatus)) < 0)
@@ -744,7 +751,6 @@ gs_spawn (const char *filename,
       if (log) log(ld, CF_LOGLEVEL_DEBUG,
 		   "cfFilterGhostscript: %s (PID %d) exited with no errors.",
 		   (pid == gspid ? "Ghostscript" : "Logging"), pid);
-      status = 0;
     }
     if (pid == gspid)
       gspid = -1;

--- a/cupsfilters/mupdftopwg.c
+++ b/cupsfilters/mupdftopwg.c
@@ -345,6 +345,13 @@ mutool_spawn(const char *filename,
 
   close(errfds[0]);
 
+  //
+  // Initialize to exit status 'Success' first - any error exit status
+  // from children process will rewrite it, and wait for children..
+  //
+
+  status = 0;
+
   while (mutoolpid > 0 || errpid > 0)
   {
     if ((pid = wait(&wstatus)) < 0)
@@ -389,7 +396,6 @@ mutool_spawn(const char *filename,
       if (log) log(ld, CF_LOGLEVEL_DEBUG,
 		   "cfFilterMuPDFToPWG: %s (PID %d) exited with no errors.",
 		   (pid == mutoolpid ? "mutool" : "Logging"), pid);
-      status = 0;
     }
     if (pid == mutoolpid)
       mutoolpid = -1;


### PR DESCRIPTION
ghostcript and mupdf filter functions did not transfer error exit code from a child and rewrote the code by successful exit code from the other child.

Fixes #76