### PR TITLE
bannertopdf.c: Fix segfault when printing banners/test page

### DIFF
--- a/cupsfilters/bannertopdf.c
+++ b/cupsfilters/bannertopdf.c
@@ -1011,7 +1011,8 @@ cfFilterBannerToPDF(int inputfd,         // I - File descriptor input stream
   banner_free(banner);
   if (options) cupsFreeOptions(num_options, options);
   unlink(tempfile);
-  fclose(inputfp);
+  if (inputfp)
+    fclose(inputfp);
   
   return (ret);
 }


### PR DESCRIPTION
I've missed the condition, because bannertopdf was missing from test suite... I'mm sorry for inconvenience.