### PR TITLE
Allow building without fontconfig

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ For non-PDF printers (excluding Mac OS X users), you must install Ghostscript wi
 - autoconf, autopoint, automake, libtool for ./autogen.sh
 - CUPS devel files (version 2.2.2 or higher)
 - Poppler (with --enable-poppler-cpp) devel files for pdftoraster
-- fontconfig devel files for texttopdf
+- fontconfig devel files for texttopdf (disable using --without-fontconfig)
 - liblcms (liblcms2 recommended) devel files for color management
 - QPDF (11.0 or higher, 11.4.0 recommended) devel files
 

--- a/configure.ac
+++ b/configure.ac
@@ -295,7 +295,13 @@ AC_ARG_WITH([fontconfig],
 	[with_fontconfig="$withval"],
 	[with_fontconfig=yes]
 )
-AS_IF([test x"$with_fontconfig" != "xno"], [
+# --disable-texttopdf will do the same thing as --without-fontconfig.
+AC_ARG_ENABLE([texttopdf],
+	[AS_HELP_STRING([--disable-texttopdf], [Disable the texttopdf filter.])],
+	[enable_texttopdf="$enableval"],
+	[enable_texttopdf=yes]
+)
+AS_IF([test x"$with_fontconfig" != "xno" && test "x$enable_texttopdf" != "xno"], [
 	AC_DEFINE([HAVE_FONTCONFIG], [1], [Defines if we are using fontconfig.])
   PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
 ])
@@ -505,6 +511,7 @@ Build configuration:
 	png:             ${with_png}
 	tiff:            ${with_tiff}
 	fontconfig:      ${with_fontconfig}
+	texttopdf:       ${enable_texttopdf}
 	dbus:            ${enable_dbus}
 	werror:          ${enable_werror}
 	test-font:       ${with_test_font_path}

--- a/configure.ac
+++ b/configure.ac
@@ -290,7 +290,15 @@ AS_IF([test x"$lcms2" = "xno"], [
 	PKG_CHECK_MODULES([LCMS], [lcms])
 	AC_DEFINE([USE_LCMS1], [1], [Defines if use lcms1])
 ])
-PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
+AC_ARG_WITH([fontconfig],
+	[AS_HELP_STRING([--without-fontconfig], [Disable fontconfig support.])],
+	[with_fontconfig="$withval"],
+	[with_fontconfig=yes]
+)
+AS_IF([test x"$with_fontconfig" != "xno"], [
+	AC_DEFINE([HAVE_FONTCONFIG], [1], [Defines if we are using fontconfig.])
+  PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
+])
 PKG_CHECK_MODULES([LIBQPDF], [libqpdf >= 11.0.0])
 
 # =================
@@ -496,6 +504,7 @@ Build configuration:
 	exif:            ${enable_exif}
 	png:             ${with_png}
 	tiff:            ${with_tiff}
+	fontconfig:      ${with_fontconfig}
 	dbus:            ${enable_dbus}
 	werror:          ${enable_werror}
 	test-font:       ${with_test_font_path}

--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -46,8 +46,10 @@
 
 static int	flush_tile(cf_image_t *img);
 static cf_ib_t	*get_tile(cf_image_t *img, int x, int y);
+#ifdef HAVE_EXIF
 static void trim_spaces(char *buf);
 static unsigned char *find_bytes(FILE *fp, long int *size);
+#endif // HAVE_EXIF
 
 //
 // 'cfImageClose()' - Close an image file.

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -23,7 +23,9 @@
 #include <cupsfilters/libcups2-private.h>
 #include <ctype.h>
 #include <errno.h>
+#ifdef HAVE_FONTCONFIG
 #include "fontconfig/fontconfig.h"
+#endif // HAVE_FONTCONFIG
 
 
 //

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -570,7 +570,7 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
   cf_logfunc_t  log = data->logfunc;
   void		*ld = data->logdata;
   if (log) log(ld, CF_LOGLEVEL_ERROR,
-	       "cfFilterTextToPDF: No fontconfig support.");
+	       "cfFilterTextToPDF: Text-to-PDF conversion not supported (no fontconfig).");
   return (1);
 #else
   texttopdf_doc_t doc;

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -15,6 +15,7 @@
 
 #include <config.h>
 
+#ifdef HAVE_FONTCONFIG
 #include <cupsfilters/pdfutils-private.h>
 #include <cupsfilters/debug-internal.h>
 #include <cupsfilters/filter.h>
@@ -2651,3 +2652,4 @@ write_pretty_header(texttopdf_doc_t *doc) // {{{
   _cfPDFOutPrintF(doc->pdf, "Q\n");
 }
 // }}}
+#endif // HAVE_FONTCONFIG

--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -15,7 +15,6 @@
 
 #include <config.h>
 
-#ifdef HAVE_FONTCONFIG
 #include <cupsfilters/pdfutils-private.h>
 #include <cupsfilters/debug-internal.h>
 #include <cupsfilters/filter.h>
@@ -56,6 +55,7 @@
 // Globals...
 //
 
+#ifdef HAVE_FONTCONFIG
 static char *code_keywords[] =	// List of known C/C++ keywords...
 	{
 	  "and",
@@ -547,6 +547,7 @@ static int      write_prolog(const char *title, const char *user,
 			    cf_logfunc_t log, void *ld);
 static void     write_page(texttopdf_doc_t *doc);
 static void     write_epilogue(texttopdf_doc_t *doc);
+#endif // HAVE_FONTCONFIG
 
 
 //
@@ -563,6 +564,13 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
 		  void *parameters)	// I - Filter-specific parameters
 					//     (unused)
 {
+#ifndef HAVE_FONTCONFIG
+  cf_logfunc_t  log = data->logfunc;
+  void		*ld = data->logdata;
+  if (log) log(ld, CF_LOGLEVEL_ERROR,
+	       "cfFilterTextToPDF: No fontconfig support.");
+  return (1);
+#else
   texttopdf_doc_t doc;
   int		i,		// Looping var
 		temp,
@@ -651,7 +659,7 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
     if (!iscanceled || !iscanceled(icd))
     {
       if (log) log(ld, CF_LOGLEVEL_DEBUG,
-		   "textopdf: Unable to open input data stream.");
+		   "cfFilterTextToPDF: Unable to open input data stream.");
     }
     return (1);
   }
@@ -1461,7 +1469,7 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
   if (empty)
   {
     if(log) log(ld, CF_LOGLEVEL_DEBUG,
-		"Input is empty, outputting empty file");
+		"cfFilterTextToPDF: Input is empty, outputting empty file");
     goto out;
   }
 
@@ -1525,8 +1533,10 @@ cfFilterTextToPDF(int inputfd,  	// I - File descriptor input stream
     free(doc.pdf);
 
   return (ret);
+#endif // HAVE_FONTCONFIG
 }
 
+#ifdef HAVE_FONTCONFIG
 
 static _cf_fontembed_emb_params_t *
 font_load(const char *font,

--- a/cupsfilters/universal.c
+++ b/cupsfilters/universal.c
@@ -168,6 +168,7 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
     }
     else
 #endif // HAVE_GHOSTSCRIPT
+#ifdef HAVE_FONTCONFIG
     if (!strcasecmp(input_super, "text") ||
 	(!strcasecmp(input_super, "application") && input_type[0] == 'x'))
     {
@@ -187,7 +188,9 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
 		   "cfFilterUniversal: Adding %s to chain",
 		   filter->name);
     }
-    else if (!strcasecmp(input, "image/urf") ||
+    else
+#endif // HAVE_FONTCONFIG
+    if (!strcasecmp(input, "image/urf") ||
 	     !strcasecmp(input, "image/pwg-raster"))
     {
       outformat = malloc(sizeof(cf_filter_out_format_t));


### PR DESCRIPTION
The texttopdf filter is the only thing using fontconfig.  Add a configure option to build without fontconfig and don't build this filter if that is specified.

The default configure is to use fontconfig, so there shoule be no changes to existing functionality.

Also, fix a minor compiler warning when building without exif.