### PR TITLE
image-zoom.c: add the xsize and ysize check to zero in _cfImageZoomNew

### DIFF
--- a/cupsfilters/image-zoom.c
+++ b/cupsfilters/image-zoom.c
@@ -92,8 +92,9 @@ _cfImageZoomNew(
   if (xsize > CF_IMAGE_MAX_WIDTH ||
       ysize > CF_IMAGE_MAX_HEIGHT ||
       (xc1 - xc0) > CF_IMAGE_MAX_WIDTH ||
-      (yc1 - yc0) > CF_IMAGE_MAX_HEIGHT)
-    return (NULL);		// Protect against integer overflow
+      (yc1 - yc0) > CF_IMAGE_MAX_HEIGHT ||
+      xsize == 0 || ysize == 0)
+    return (NULL);		// Protect against integer overflow and divide by zero
 
   if ((z = (cf_izoom_t *)calloc(1, sizeof(cf_izoom_t))) == NULL)
     return (NULL);

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -1680,6 +1680,8 @@ cfFilterImageToRaster(int inputfd,         // I - File descriptor input stream
 			      (doc.Orientation > 1 ? -1 : 1) * xtemp,
 			      (doc.Orientation > 1 ? -1 : 1) * ytemp,
 			      doc.Orientation & 1, zoom_type);
+	  if (z == NULL) continue;
+
 	  //
 	  // Write leading blank space as needed...
 	  //


### PR DESCRIPTION
When calculating z->xmod, z->xstep, etc., if xsize and ysize are zero, division by zero occurs. To avoid this, the xsize and ysize check for zero is added at the beginning of the function.