### PR TITLE
imagetopdf: convert custom media size min_width and min_height to points. Fixes #87

### DIFF
--- a/cupsfilters/imagetopdf.c
+++ b/cupsfilters/imagetopdf.c
@@ -769,6 +769,8 @@ cfFilterImageToPDF(int inputfd,         // I - File descriptor input stream
     customBottom = bottom * 72.0 / 2540.0;
     customRight = right * 72.0 / 2540.0;
     customTop = top * 72.0 / 2540.0;
+    min_width = min_width * 72 / 2540;
+    min_length = min_length * 72 / 2540;
   }
 
   //


### PR DESCRIPTION
When VariablePaperSize code failed, Custom page size incorrectly assumes min_width/min_length in points, not in PWG hundredths of millimeters.

See #87.