### PR TITLE
Fix NULL-pointer dereference when parsing %PDFTOPDF comments

### DIFF
--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -109,6 +109,7 @@ parse_pdf_header_options(FILE *fp,
         h->Collate = CUPS_FALSE;
         continue;
       }
+      p ++;
       while (*p == ' ' || *p == '\t')
 	p ++;
       if (strncasecmp(p, "true", 4) == 0)

--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -92,6 +92,11 @@ parse_pdf_header_options(FILE *fp,
       char *p;
 
       p = strchr(buf + 19, ':');
+      if (!p)
+      {
+        h->NumCopies = 1;
+        continue;
+      }
       h->NumCopies = atoi(p + 1);
     }
     else if (strncmp(buf, "%%PDFTOPDFCollate", 17) == 0)
@@ -99,6 +104,11 @@ parse_pdf_header_options(FILE *fp,
       char *p;
 
       p = strchr(buf + 17, ':');
+      if (!p)
+      {
+        h->Collate = CUPS_FALSE;
+        continue;
+      }
       while (*p == ' ' || *p == '\t')
 	p ++;
       if (strncasecmp(p, "true", 4) == 0)

--- a/cupsfilters/mupdftopwg.c
+++ b/cupsfilters/mupdftopwg.c
@@ -102,6 +102,7 @@ parse_pdf_header_options(FILE *fp,
         h->Collate = CUPS_FALSE;
         continue;
       }
+      p ++;
       while (*p == ' ' || *p == '\t')
 	p ++;
       if (strncasecmp(p, "true", 4) == 0)

--- a/cupsfilters/mupdftopwg.c
+++ b/cupsfilters/mupdftopwg.c
@@ -85,6 +85,11 @@ parse_pdf_header_options(FILE *fp,
       char *p;
 
       p = strchr(buf + 19, ':');
+      if (!p)
+      {
+	h->NumCopies = 1;
+	continue;
+      }
       h->NumCopies = atoi(p + 1);
     }
     else if (strncmp(buf, "%%PDFTOPDFCollate", 17) == 0)
@@ -92,6 +97,11 @@ parse_pdf_header_options(FILE *fp,
       char *p;
 
       p = strchr(buf + 17, ':');
+      if (!p)
+      {
+        h->Collate = CUPS_FALSE;
+        continue;
+      }
       while (*p == ' ' || *p == '\t')
 	p ++;
       if (strncasecmp(p, "true", 4) == 0)

--- a/cupsfilters/pdftoraster.cxx
+++ b/cupsfilters/pdftoraster.cxx
@@ -446,6 +446,7 @@ parse_pdftopdf_comment(FILE *fp,
 	*deviceCollate = false;
 	continue;
       }
+      p ++;
       while (*p == ' ' || *p == '\t') p ++;
       if (strncasecmp(p, "true", 4) == 0)
 	*deviceCollate = true;

--- a/cupsfilters/pdftoraster.cxx
+++ b/cupsfilters/pdftoraster.cxx
@@ -429,6 +429,11 @@ parse_pdftopdf_comment(FILE *fp,
       char *p;
 
       p = strchr(buf + 19, ':');
+      if (!p)
+      {
+	(*deviceCopies) = 1;
+	continue;
+      }
       (*deviceCopies) = atoi(p + 1);
     }
     else if (strncmp(buf, "%%PDFTOPDFCollate", 17) == 0)
@@ -436,6 +441,11 @@ parse_pdftopdf_comment(FILE *fp,
       char *p;
 
       p = strchr(buf + 17, ':');
+      if (!p)
+      {
+	*deviceCollate = false;
+	continue;
+      }
       while (*p == ' ' || *p == '\t') p ++;
       if (strncasecmp(p, "true", 4) == 0)
 	*deviceCollate = true;


### PR DESCRIPTION
The problem here is that the `strchr()` function may return NULL if the requested character is not provided in the input. The pointer is then dereferenced, which crashes the program.

Commit 1 fixes the NULL-pointer dereference, but has no functional change.

I additionally observed that the parsing logic is broken for `%%PDFTOPDFCollate` in some cases - in some places where this code was copied, because `p` still points to the colon character, the loop and string comparison conditions do not make sense.  Commit 2 fixes that, but it is admittedly a change in functionality, which is why I kept the two separate.  I'm perfectly fine with it if you don't want to apply that second commit.

Same PR for cups-filters 1.x branch: https://github.com/OpenPrinting/cups-filters/pull/644