### PR TITLE
configure.ac: Make CJK fonts name configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ test-analyze
 Test_summary_final.txt
 test.pdf
 test.ps
+
+# ignore generated charset file
+charset/pdf.utf-8.simple
+charset/pdf.utf-8.heavy

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,9 @@ EXTRA_DIST = \
 	$(doc_DATA) \
 	autogen.sh \
 	config.rpath \
-	libcupsfilters.pc.in
+	libcupsfilters.pc.in \
+	pdf.utf-8.heavy.in \
+	pdf.utf-8.simple.in
 
 EXTRA_DIST += \
 	data/makePDFfromPS.sh \

--- a/charset/pdf.utf-8.heavy.in
+++ b/charset/pdf.utf-8.heavy.in
@@ -28,7 +28,14 @@ charset utf8
 # printing.
 #
 
-0000 04FF ltor single monospace monospace:bold monospace:oblique monospace:bold:oblique
-0500 05FF rtol single monospace
-0600 06FF rtol single monospace
-3000 9FFF ltor double ARPLUmingCN
+0000 00FF ltor single CourierNew CourierNew:bold CourierNew:italic CourierNew:bold:italic
+0100 02FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
+0300 03FF ltor single DejaVuSansMono
+0400 04FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
+0500 05FF rtol single FreeMono
+0600 06FF rtol single FreeMono
+1E00 1EFF ltor single CourierNew CourierNew:bold CourierNew:italic CourierNew:bold:italic
+2000 21FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
+2200 23FF ltor single Symbol
+3000 9FFF ltor double @CJKFONTS@
+#0400 04FF ltor single FreeMono FreeMono:bold FreeMono:oblique FreeMono:bold:oblique

--- a/charset/pdf.utf-8.simple.in
+++ b/charset/pdf.utf-8.simple.in
@@ -28,14 +28,7 @@ charset utf8
 # printing.
 #
 
-0000 00FF ltor single CourierNew CourierNew:bold CourierNew:italic CourierNew:bold:italic
-0100 02FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
-0300 03FF ltor single DejaVuSansMono
-0400 04FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
-0500 05FF rtol single FreeMono
-0600 06FF rtol single FreeMono
-1E00 1EFF ltor single CourierNew CourierNew:bold CourierNew:italic CourierNew:bold:italic
-2000 21FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
-2200 23FF ltor single Symbol
-3000 9FFF ltor double ARPLUMingCN
-#0400 04FF ltor single FreeMono FreeMono:bold FreeMono:oblique FreeMono:bold:oblique
+0000 04FF ltor single monospace monospace:bold monospace:oblique monospace:bold:oblique
+0500 05FF rtol single monospace
+0600 06FF rtol single monospace
+3000 9FFF ltor double @CJKFONTS@

--- a/configure.ac
+++ b/configure.ac
@@ -478,12 +478,26 @@ CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE -DPOINTERHOLDER_TRANSITION=0"
 #                                      See /usr/include/qpdf/PointerHolder.hh
 CXXFLAGS="$CXXFLAGS -std=c++17"
 
+# =========
+# CJK FONTS
+# =========
+AC_ARG_WITH([cjk-fonts],
+	[AS_HELP_STRING([--with-cjk-fonts=value], [Set font name for CJK fonts (default: ARPLUmingCN).])],
+	[AS_IF([test "x$withval" != "x" -a "x$withval" != "xyes" -a "x$withval" != "xno"],
+	       [CJKFONTS="$withval"],
+	       [CJKFONTS="ARPLUmingCN"])],
+	[CJKFONTS="ARPLUmingCN"])
+
+AC_SUBST([CJKFONTS])
+
 # =====================
 # Prepare all .in files
 # =====================
 AC_CONFIG_FILES([
 	libcupsfilters.pc
 	Makefile
+	charset/pdf.utf-8.heavy
+	charset/pdf.utf-8.simple
 ])
 AC_OUTPUT
 
@@ -515,5 +529,6 @@ Build configuration:
 	dbus:            ${enable_dbus}
 	werror:          ${enable_werror}
 	test-font:       ${with_test_font_path}
+	cjk-fonts:       ${CJKFONTS}
 ==============================================================================
 ])


### PR DESCRIPTION
Distributions might want to use a different CJK font family to support Chinese, Japanese and Korean fonts. The MR introduces `--with-cjk-fonts` configuration option which sets the fonts name.