### PR TITLE
Update build system and documentation for PDFio 1.6.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,13 +25,13 @@ jobs:
        sudo apt install autotools-dev autopoint cmake libtool pkg-config libcups2-dev libexif-dev liblcms2-dev libfontconfig1-dev
        sudo apt install libfreetype6-dev build-essential qtbase5-dev qtchooser libcairo2-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev libopenjp2-7-dev liblcms2-dev libjpeg-dev
        sudo apt install -y libjxl-dev
-    - name: Install pdfio >= 1.5.3
+    - name: Install pdfio >= 1.6.0
       run: |
         cd ..
         mkdir pdfio
-        wget https://github.com/michaelrsweet/pdfio/releases/download/v1.5.3/pdfio-1.5.3.tar.gz
-        tar -xzf pdfio-1.5.3.tar.gz
-        cd pdfio-1.5.3
+        wget https://github.com/michaelrsweet/pdfio/releases/download/v1.6.0/pdfio-1.6.0.tar.gz
+        tar -xzf pdfio-1.6.0.tar.gz
+        cd pdfio-1.6.0
         ./configure --prefix=/usr --enable-shared
         make all
         make test

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ For non-PDF printers (excluding Mac OS X users), you must install Ghostscript wi
 - CUPS devel files (version 2.2.2 or higher)
 - fontconfig devel files for texttopdf (disable using --without-fontconfig)
 - liblcms (liblcms2 recommended) devel files for color management
-- PDFio (1.5.3 or higher) devel files
+- PDFio (1.6.0 or higher) devel files
 
 ### Additional Binaries for Non-PDF Printers
 - Ghostscript 10.01.1 or higher (with specific output devices support)

--- a/configure.ac
+++ b/configure.ac
@@ -325,7 +325,7 @@ AS_IF([test x"$with_fontconfig" != "xno" && test "x$enable_texttopdf" != "xno"],
 	AC_DEFINE([HAVE_FONTCONFIG], [1], [Defines if we are using fontconfig.])
   PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.0.0])
 ])
-PKG_CHECK_MODULES([LIBPDFIO], [pdfio >= 1.5.3])
+PKG_CHECK_MODULES([LIBPDFIO], [pdfio >= 1.6.0])
 
 
 # =================


### PR DESCRIPTION
The recent release of PDFio 1.6.0 fixed the following issue:
- Fixed EOF comment written to the PDF (Issue [#136](https://github.com/michaelrsweet/pdfio/pull/136))

The above fix is crucial for pdf EOF comment which was "%EOF" to "%%EOF" 