### PR TITLE
Fix for security vulnerablity due to system() function

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
       run: |
        sudo apt install libpoppler-cpp-dev libpython3-dev libdbus-1-dev
        sudo apt install mupdf-tools
+       sudo apt install -y poppler-utils
        
     - name: Install ghostscript
       run: sudo apt install ghostscript

--- a/configure.ac
+++ b/configure.ac
@@ -388,7 +388,7 @@ AC_ARG_WITH([ippfind-path],
 
 CUPS_GHOSTSCRIPT=""
 AS_IF([test "x$enable_ghostscript" != "xyes"], [
-       with_gs_path=""
+      with_gs_path=""
 ], [
 	AS_IF([test "x$with_gs_path" != "xsystem"], [
 		CUPS_GHOSTSCRIPT="$with_gs_path"
@@ -406,6 +406,33 @@ AS_IF([test "x$enable_ghostscript" != "xyes"], [
 ])
 AM_CONDITIONAL(ENABLE_GHOSTSCRIPT, test "x$enable_ghostscript" = xyes)
 AC_SUBST(CUPS_GHOSTSCRIPT)
+
+# ====================
+# Check for pdftoppm
+# ====================
+AC_ARG_WITH([pdftoppm-path],
+	[AS_HELP_STRING([--with-pdftoppm-path=value], [Set path to pdftoppm binary (default: system).])],
+       	[with_pdftoppm_path="$withval"],
+       	[with_pdftoppm_path=system]
+)
+
+PDFTOPPM_COMMAND=""
+AS_IF([test "x$with_pdftoppm_path" != "xsystem"], [
+      PDFTOPPM_COMMAND="$with_pdftoppm_path"
+], [
+	AS_IF([test "x$cross_compiling" = "xyes"], [
+		PDFTOPPM_COMMAND="pdftoppm"
+	], [
+		AC_CHECK_PROG(PDFTOPPM_COMMAND, pdftoppm, pdftoppm) 
+	])
+])
+
+AS_IF([test "x$PDFTOPPM_COMMAND" = "x"], [
+	AC_MSG_ERROR([Required pdftoppm binary is missing. Please install poppler-utils package.])
+])
+
+AC_DEFINE_UNQUOTED([PDFTOPPM_COMMAND], ["$PDFTOPPM_COMMAND"], [Full path to pdftoppm executable])
+AC_SUBST(PDFTOPPM_COMMAND)
 
 # ================
 # Check for mutool

--- a/cupsfilters/pdftoraster.c
+++ b/cupsfilters/pdftoraster.c
@@ -1529,7 +1529,7 @@ write_page_image(cups_raster_t *raster,
   int ret;		// exit status
   pid_t pid = fork();	// child process
 
-  if (pid == -1)	// fork failedd
+  if (pid == -1)	// fork failed
   {
     if (doc->logfunc) doc->logfunc(doc->logdata, CF_LOGLEVEL_ERROR,
                                    "Failed to fork process for pdftoppm");

--- a/cupsfilters/pdftoraster.c
+++ b/cupsfilters/pdftoraster.c
@@ -1554,6 +1554,7 @@ write_page_image(cups_raster_t *raster,
     int out_fd = open(img_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (out_fd == -1)
     {
+      // Use _exit() in child process for safety
       if (doc->logfunc) doc->logfunc(doc->logdata, CF_LOGLEVEL_ERROR,
                                      "pdftoraster: Failed to open output file %s", img_path);
       _exit(127);
@@ -1609,9 +1610,7 @@ write_page_image(cups_raster_t *raster,
     argv[arg_index++] = NULL;                // End of the array
 
     // Define the path and call execv
-    // NOTE: This path is hardcoded. If pdftoppm is elsewhere,
-    // this will fail. Using execv() would search the PATH.
-    const char *pathname = "/usr/bin/pdftoppm";
+    const char *pathname = PDFTOPPM_COMMAND;
     execv(pathname, argv);
 
     // If execv returns, an error occurred


### PR DESCRIPTION
As system() function receives the whole command line as a stringwhich is interpreted by a shell, and so with a forged parameter one can inject the execution of an arbitrary command here. Imagine that doc->input_filename is set to '; rm -rf /; ' (including the single quotes before and after).

This may lead to a SQL injecting vulnerability.

the fix uses use of fork() and execve() functions.