### PR TITLE
Fix cache thrashing for large images

### DIFF
--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -653,7 +653,7 @@ cfImageCrop(cf_image_t* img,
   cf_ib_t *pixels = (cf_ib_t*)malloc(img->xsize * cfImageGetDepth(img));
 
   temp->cachefile = -1;
-  temp->max_ics = CF_TILE_MINIMUM;
+  temp->max_ics = img->max_ics;
   temp->colorspace = img->colorspace;
   temp->xppi = img->xppi;
   temp->yppi = img->yppi;


### PR DESCRIPTION
`cfImageCrop` constructs a new image with the default tile cache size. This create disastrously bad performance on large images.

For example, calling `imagetoraster` on an ARCHE sized page (36x48 inches, 21600 pixels wide) takes over 300s before this patch, all of which is in libc_read and libc_write. The cache size is 10 tiles, but the required cache size is actually about 900-1000 tiles.  With the patch, the temp image correctly inherits a bigger cache (that was sized using the image width), and that same invocation costs 40s.