### PR TITLE
[Draft] Add two PoC testcases to libcupsfilters test suite (text→PDF and malformed PDF)

### DIFF
--- a/cupsfilters/test-filter-cases.txt
+++ b/cupsfilters/test-filter-cases.txt
@@ -19,3 +19,8 @@ cupsfilters/test_files/test_file_4pg.pdf	application/pdf	cupsfilters/test_files/
 cupsfilters/test_files/test_file_4pg.pdf	application/pdf	cupsfilters/test_files/output_files/test_file_op.pwg	image/pwg-raster	Generic	PDF Color 2	1	1	image/pwg-raster,application/pdf	13	new-user	custom-print	5	sides=two-sided-short-edge media-size=A4 printer-resolution=300dpi
 cupsfilters/test_files/onepage-a4-adobe-rgb-8-150dpi.pwg	image/pwg-raster	cupsfilters/test_files/output_files/test_pwgtoraster.pdf	application/pdf	Generic	PDF Color 2	1 	1	application/pdf,image/pwg-raster	13	new-user	custom-print	5	sides=two-sided-short-edge media-size=A4 printer-resolution=300dpi
 cupsfilters/test_files/onepage-a4-adobe-rgb-8-150dpi.pwg	image/pwg-raster	cupsfilters/test_files/output_files/test_pwgtoraster.pclm	application/pclm	Generic	PDF Color 2	1 	1	application/pclm,image/pwg-raster	13	new-user	custom-print	5	sides=two-sided-short-edge media-size=A4 printer-resolution=300dpi
+# === PoC testcases added for CI expansion ===
+# 1. text/plain → PDF (tests texttopdf)
+# 2. malformed PDF → PDF (currently pass-through; does not yet trigger Ghostscript(although I expected it to))
+cupsfilters/test_files/test_text_simple.txt	text/plain	cupsfilters/test_files/output_files/output_text_simple.pdf	application/pdf	Generic	PDF Color 2	1	1	text/plain,application/pdf	201	poc-user	poc-print	1
+cupsfilters/test_files/malformed.pdf	application/pdf	cupsfilters/test_files/output_files/output_malformed_should_fail.pdf	application/pdf	Generic	PDF Color 2	1	1	application/pdf	202	poc-user-malformed	expect-fail	1

--- a/cupsfilters/test_files/malformed.pdf
+++ b/cupsfilters/test_files/malformed.pdf
@@ -1,0 +1,2 @@
+NotAPDF
+%EOF

--- a/cupsfilters/test_files/test_text_simple.txt
+++ b/cupsfilters/test_files/test_text_simple.txt
@@ -1,0 +1,1 @@
+Hello My First OpenPrinting PoC — page 1


### PR DESCRIPTION
### Summary

This draft PR adds two small Proof-of-Concept testcases to  `cupsfilters/test-filter-cases.txt`, along with their corresponding input files in `cupsfilters/test_files/`.

The purpose of this PoC is to better understand how the libcupsfilters test harness (`testfilters`) behaves for simple input→output scenarios, and to explore how we can later expand automated CI coverage using such testcases.

This PR is **not intended for merging yet** — it is meant for discussion, feedback, and refinement of directions for future test additions.

---

### Added Testcases

#### 1. `text/plain → application/pdf` (Positive Test)

**Entry added to `test-filter-cases.txt`:**

```text
cupsfilters/test_files/test_text_simple.txt	text/plain	cupsfilters/test_files/output_files/output_text_simple.pdf	application/pdf	Generic	PDF Color 2	1	1	text/plain,application/pdf	201	poc-user	poc-print	1
```
#### Local Behavior (PoC-Only Test Run)
**Ran:**

```bash
./testfilters cupsfilters/test-filter-cases-poc.txt 2 2
```

 **From the log:**

- Converting from text/plain to application/pdf
- Adding texttopdf to chain
- texttopdf completed with status 0
- Test Status 1: Successful

The output file "cupsfilters/test_files/output_files/output_text_simple.pdf" was created successfully (~1125 bytes) and appears as a valid PDF.

**Conclusion:**
This PoC correctly exercises the texttopdf filter and demonstrates that the test harness handles simple text→PDF transforms reliably.

#### 2. `malformed PDF → application/pdf` (Exploratory “Negative” Test)

**Entry added to `test-filter-cases.txt`:**
```text
cupsfilters/test_files/malformed.pdf	application/pdf cupsfilters/test_files/output_files/output_malformed_should_fail.pdf	application/pdf	Generic	PDF Color 2	1	1	application/pdf	202	poc-user-malformed	expect-fail	1
```

#### **malformed.pdf is a deliberately invalid “PDF” consisting of:**
```text
NotAPDF
%EOF
```

#### Local behavior (same PoC-only run as above)

**From the log:**

- Converting from application/pdf to application/pdf
- No filter at all in chain, passing through the data
- Test Status 2: Successful 

The output file "cupsfilters/test_files/output_files/output_malformed_should_fail.pdf" was created with size 26 bytes, i.e. essentially a direct copy of the malformed input.(although I was expecting a Ghostscript failure)

**From observation I think the reason this happens:**

- For application/pdf → application/pdf, the universal filter detects that no transformation is needed and selects no filter chain.
- As a result, the malformed PDF never reaches Ghostscript and therefore does not produce errors such as:
  - “Missing Root object”
  - “Unable to find start of cross-reference table”
  - “Unexpected page count”

**Conclusion:**
This PoC demonstrates the current behavior: malformed-PDF handling only triggers Ghostscript failures when the test requests a transformation such as PDF→PWG or PDF→PCLm.