### PR TITLE
texttopdf: default to UTF-8 when charset metadata is missing

### DIFF
--- a/cupsfilters/texttopdf.c
+++ b/cupsfilters/texttopdf.c
@@ -1958,6 +1958,14 @@ write_prolog(const char *title,		// I - Title of job
   // Get the output character set...
   //
 
+  //
+  // If no charset was provided by the filter framework, or metadata,
+  // default to UTF-8 so that Unicode charsets can be resolved, as this value
+  // is directly used in charset value to activate UTF-8 path.
+  //
+  if (!doc->env_vars.char_set)
+    doc->env_vars.char_set = "utf-8";
+
   charset = doc->env_vars.char_set;
   if (charset != NULL && strcmp(charset, "us-ascii") != 0) // {{{
   {


### PR DESCRIPTION
texttopdf relies entirely on charset metadata to activate its UTF-8 and Unicode rendering path. In many real-world jobs, charset metadata is missing. So, even when input is UTF-8., the code silently falls back to ASCII output using Type1 fonts.

Default to UTF-8 when no charset metadata is present so the existing Unicode pipeline (charset files, Fontconfig, CID Type0 fonts, and ToUnicode mappings) is correctly activated.

This code snippet is responsible for setting char_set, if the parameter(passed by the filter framework) is null, which in most of the case is, then there was no way to let the texttopdf pipeline know that the content is UTF-8 and not ASCII.

if (parameters)
  doc.env_vars = *((cf_filter_texttopdf_parameter_t *)parameters);
else
{
  doc.env_vars.data_dir = CUPS_DATADIR;
  doc.env_vars.char_set = NULL;
  doc.env_vars.content_type = NULL;
  doc.env_vars.classification = NULL;
}

And as ASCII is subset of UTF-8, the best course of action is to use UTF-8 as the default.