### PR TITLE
charset: Add Devanagari Unicode range to utf-8 charsets

### DIFF
--- a/charset/pdf.utf-8.heavy.in
+++ b/charset/pdf.utf-8.heavy.in
@@ -37,5 +37,6 @@ charset utf8
 1E00 1EFF ltor single CourierNew CourierNew:bold CourierNew:italic CourierNew:bold:italic
 2000 21FF ltor single DejaVuSansMono DejaVuSansMono:bold DejaVuSansMono:oblique DejaVuSansMono:bold:oblique
 2200 23FF ltor single Symbol
+0900 097F ltor single NotoSansDevanagari NotoSansDevanagari:bold NotoSansDevanagari:oblique NotoSansDevanagari:bold:oblique
 3000 9FFF ltor double @CJKFONTS@
 #0400 04FF ltor single FreeMono FreeMono:bold FreeMono:oblique FreeMono:bold:oblique

--- a/charset/pdf.utf-8.simple.in
+++ b/charset/pdf.utf-8.simple.in
@@ -31,4 +31,5 @@ charset utf8
 0000 04FF ltor single monospace monospace:bold monospace:oblique monospace:bold:oblique
 0500 05FF rtol single monospace
 0600 06FF rtol single monospace
+0900 097F ltor single NotoSansDevanagari
 3000 9FFF ltor double @CJKFONTS@


### PR DESCRIPTION
This PR adds the Devanagari Unicode range (U+0900-097F) to the `pdf.utf-8` charset configurations in `texttopdf`. This enables the filter to correctly map Devanagari text to appropriate fonts (like `NotoSansDevanagari`).

Currently, `libcupsfilters` does not support Devanagari out of the box, preventing the generation of PDFs containing Hindi text. 

*Note: For this mapping to resolve successfully with proportional fonts like Noto Sans Devanagari, the strict `FC_MONO` constraint in Fontconfig candidate filtering must be removed. I have submitted that C code fix in a separate companion [PR](https://github.com/OpenPrinting/libcupsfilters/pull/140).*