### PR TITLE
pdftopdf QPDF: Ghostscript transparency performance optimization

### DIFF
--- a/cupsfilters/pdftopdf/qpdf-pdftopdf-processor-private.h
+++ b/cupsfilters/pdftopdf/qpdf-pdftopdf-processor-private.h
@@ -46,6 +46,14 @@ class _cfPDFToPDFQPDFPageHandle : public _cfPDFToPDFPageHandle {
   std::string content;
 
   pdftopdf_rotation_e rotation;
+
+  // Group transparency tracking for safe optimization
+  struct SubpageInfo {
+    QPDFObjectHandle page_handle;
+    QPDFObjectHandle group;
+    std::string xoname;
+  };
+  std::vector<SubpageInfo> subpage_info; // Track subpage details for deferred XObject creation
 };
 
 class _cfPDFToPDFQPDFProcessor : public _cfPDFToPDFProcessor {

--- a/cupsfilters/pdftopdf/qpdf-pdftopdf-processor.cxx
+++ b/cupsfilters/pdftopdf/qpdf-pdftopdf-processor.cxx
@@ -371,6 +371,13 @@ _cfPDFToPDFQPDFPageHandle::add_subpage
 					     rect.right, rect.top));
     // TODO? do everything for cropping here?
   }
+
+  // Preserve /Group from subpage to container page for performance
+  if (qsub->page.hasKey("/Group"))
+  {
+    page.replaceKey("/Group", qsub->page.getKey("/Group"));
+  }
+
   xobjs[xoname] = _cfPDFToPDFMakeXObject(qsub->page.getOwningQPDF(),
 					 qsub->page); // trick: should be the
                                                       // same as
@@ -420,9 +427,22 @@ _cfPDFToPDFQPDFPageHandle::mirror() // {{{
 
     QPDFObjectHandle subpage = get();  // this->page, with rotation
 
+    // Preserve /Group from the original page
+    QPDFObjectHandle group;
+    if (subpage.hasKey("/Group"))
+    {
+      group = subpage.getKey("/Group");
+    }
+
     // replace all our data
     *this = _cfPDFToPDFQPDFPageHandle(subpage.getOwningQPDF(),
 				      orig.width, orig.height);
+
+    // Apply /Group to the new wrapper page for performance
+    if (group.isInitialized())
+    {
+      page.replaceKey("/Group", group);
+    }
 
     xobjs[xoname] = _cfPDFToPDFMakeXObject(subpage.getOwningQPDF(), subpage);
                                        // we can only now set this->xobjs

--- a/cupsfilters/pdftopdf/qpdf-pdftopdf-processor.cxx
+++ b/cupsfilters/pdftopdf/qpdf-pdftopdf-processor.cxx
@@ -105,6 +105,67 @@ _cfPDFToPDFQPDFPageHandle::get() // {{{
 
   if (!is_existing())
   { // finish up page
+    // Smart /Group transparency optimization
+    bool copyGroupToXObjects = false;
+
+    if (!subpage_info.empty())
+    {
+      // Check if we have multiple subpages
+      if (subpage_info.size() == 1)
+      {
+        // Single subpage: safe to promote /Group to page level
+        if (!subpage_info[0].group.isNull())
+        {
+          page.replaceKey("/Group", subpage_info[0].group);
+          copyGroupToXObjects = false; // Don't copy to XObject for performance
+        }
+      }
+      else
+      {
+        // Multiple subpages: check if all have identical /Group
+        bool allSame = true;
+        bool allHaveGroup = true;
+        QPDFObjectHandle firstGroup = subpage_info[0].group;
+
+        for (size_t i = 0; i < subpage_info.size(); i++)
+        {
+          if (subpage_info[i].group.isNull())
+          {
+            allHaveGroup = false;
+            allSame = false;
+            break;
+          }
+          if (i > 0)
+          {
+            // Compare groups (simplified: check if they're the same object or equal dictionaries)
+            if (subpage_info[i].group.unparse() != firstGroup.unparse())
+            {
+              allSame = false;
+              break;
+            }
+          }
+        }
+
+        if (allHaveGroup && allSame)
+        {
+          // All subpages have identical /Group: promote to page level
+          page.replaceKey("/Group", firstGroup);
+          copyGroupToXObjects = false;
+        }
+        else
+        {
+          // Different /Group settings: keep them in XObjects (fallback to current behavior)
+          copyGroupToXObjects = true;
+        }
+      }
+
+      // Now create the XObjects with the appropriate /Group handling
+      for (const auto& info : subpage_info)
+      {
+        xobjs[info.xoname] = _cfPDFToPDFMakeXObject(info.page_handle.getOwningQPDF(), info.page_handle, copyGroupToXObjects);
+      }
+    }
+
     page.getKey("/Resources").replaceKey("/XObject",
 					 QPDFObjectHandle::newDictionary(xobjs));
     content.append("Q\n");
@@ -372,18 +433,16 @@ _cfPDFToPDFQPDFPageHandle::add_subpage
     // TODO? do everything for cropping here?
   }
 
-  // Preserve /Group from subpage to container page for performance
-  if (qsub->page.hasKey("/Group"))
-  {
-    page.replaceKey("/Group", qsub->page.getKey("/Group"));
-  }
+  // Store subpage information for deferred XObject creation with smart /Group handling
+  SubpageInfo info;
+  info.page_handle = qsub->page;
+  info.group = qsub->page.hasKey("/Group") ? qsub->page.getKey("/Group") : QPDFObjectHandle::newNull();
+  info.xoname = xoname;
+  subpage_info.push_back(info);
 
-  xobjs[xoname] = _cfPDFToPDFMakeXObject(qsub->page.getOwningQPDF(),
-					 qsub->page); // trick: should be the
-                                                      // same as
-                                                      // page->getOwningQPDF()
-                                                      // [only after it's made
-                                                      // indirect]
+  // Note: XObject will be created in get() with smart /Group optimization
+  // Store a placeholder for now
+  xobjs[xoname] = QPDFObjectHandle::newNull();
 
   _cfPDFToPDFMatrix mtx;
   mtx.translate(xpos, ypos);
@@ -438,13 +497,15 @@ _cfPDFToPDFQPDFPageHandle::mirror() // {{{
     *this = _cfPDFToPDFQPDFPageHandle(subpage.getOwningQPDF(),
 				      orig.width, orig.height);
 
-    // Apply /Group to the new wrapper page for performance
+    // Apply /Group to the new wrapper page for performance optimization
+    // Safe for single-page wrapping: /Group stays at page level, not in XObject
     if (group.isInitialized())
     {
       page.replaceKey("/Group", group);
     }
 
-    xobjs[xoname] = _cfPDFToPDFMakeXObject(subpage.getOwningQPDF(), subpage);
+    // Single page wrapping: don't copy /Group to XObject (copyGroup=false for performance)
+    xobjs[xoname] = _cfPDFToPDFMakeXObject(subpage.getOwningQPDF(), subpage, false);
                                        // we can only now set this->xobjs
 
     // content.append(std::string("1 0 0 1 0 0 cm\n  ");

--- a/cupsfilters/pdftopdf/qpdf-xobject-private.h
+++ b/cupsfilters/pdftopdf/qpdf-xobject-private.h
@@ -8,6 +8,6 @@
 
 #include <qpdf/QPDFObjectHandle.hh>
 
-QPDFObjectHandle _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page);
+QPDFObjectHandle _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page, bool copyGroup = false);
 
 #endif // !_CUPS_FILTERS_PDFTOPDF_QPDF_XOBJECT_H_

--- a/cupsfilters/pdftopdf/qpdf-xobject.cxx
+++ b/cupsfilters/pdftopdf/qpdf-xobject.cxx
@@ -67,7 +67,7 @@ CombineFromContents_Provider::provideStreamData(int objid,
 //                        /used/ -- or set /Matrix)
 //  [/UserUnit] (PDF 1.6)   -> to /Matrix ?   -- it MUST be handled.
 //
-//  [/Group dict]      -> copy
+//  [/Group dict]      -> keep in /Page, do not copy to /XObject (performance)
 //  [/Thumb stream]    -> remove, not needed any more / would have to be
 //                        regenerated (combined)
 //  [/B]               article beads -- ignore for now
@@ -141,10 +141,8 @@ _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
   dict.replaceKey("/Matrix", mtx.get());
 
   dict.replaceKey("/Resources", page.getKey("/Resources"));
-  if (page.hasKey("/Group"))
-    dict.replaceKey("/Group", page.getKey("/Group")); // (transparency); opt,
-                                                      // copy if there
 
+  // Note: /Group is kept in the /Page and not copied to /XObject for performance reasons
   // ?? /StructParents   ... can basically copy from page, but would need
   // fixup in Structure Tree
   // FIXME: remove (globally) Tagged spec (/MarkInfo), and Structure Tree
@@ -188,7 +186,7 @@ _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
 //   [/Matrix .]   ...  default is [1 0 0 1 0 0] ---   we have to incorporate
 //                      /UserUnit here?!
 //   [/Resources dict]  from page.
-//   [/Group dict]      used for transparency -- can copy from page
+//   [/Group dict]      used for transparency -- kept in /Page, not copied to /XObject for performance
 //   [/Ref dict]        not needed; for external reference
 //   [/Metadata]        not, as long we can not combine.
 //   [/PieceInfo]       can copy, but not combine 

--- a/cupsfilters/pdftopdf/qpdf-xobject.cxx
+++ b/cupsfilters/pdftopdf/qpdf-xobject.cxx
@@ -67,7 +67,7 @@ CombineFromContents_Provider::provideStreamData(int objid,
 //                        /used/ -- or set /Matrix)
 //  [/UserUnit] (PDF 1.6)   -> to /Matrix ?   -- it MUST be handled.
 //
-//  [/Group dict]      -> keep in /Page, do not copy to /XObject (performance)
+//  [/Group dict]      -> keep in /Page, do not copy to /XObject unless different across pages (performance)
 //  [/Thumb stream]    -> remove, not needed any more / would have to be
 //                        regenerated (combined)
 //  [/B]               article beads -- ignore for now
@@ -99,7 +99,7 @@ CombineFromContents_Provider::provideStreamData(int objid,
 //
 
 QPDFObjectHandle
-_cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
+_cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page, bool copyGroup)
 {
   page.assertPageObject();
 
@@ -142,7 +142,12 @@ _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
 
   dict.replaceKey("/Resources", page.getKey("/Resources"));
 
-  // Note: /Group is kept in the /Page and not copied to /XObject for performance reasons
+  // Copy /Group to XObject only if requested (when multiple subpages have different groups)
+  if (copyGroup && page.hasKey("/Group"))
+  {
+    dict.replaceKey("/Group", page.getKey("/Group"));
+  }
+  // Note: By default, /Group is kept in the /Page and not copied to /XObject for performance reasons
   // ?? /StructParents   ... can basically copy from page, but would need
   // fixup in Structure Tree
   // FIXME: remove (globally) Tagged spec (/MarkInfo), and Structure Tree
@@ -186,7 +191,7 @@ _cfPDFToPDFMakeXObject(QPDF *pdf, QPDFObjectHandle page)
 //   [/Matrix .]   ...  default is [1 0 0 1 0 0] ---   we have to incorporate
 //                      /UserUnit here?!
 //   [/Resources dict]  from page.
-//   [/Group dict]      used for transparency -- kept in /Page, not copied to /XObject for performance
+//   [/Group dict]      used for transparency -- kept in /Page, not copied to /XObject unless different across pages for performance
 //   [/Ref dict]        not needed; for external reference
 //   [/Metadata]        not, as long we can not combine.
 //   [/PieceInfo]       can copy, but not combine 


### PR DESCRIPTION
Forward-port of the same changes for cups-filters 1.x: https://github.com/OpenPrinting/cups-filters/pull/669
Original issue: https://github.com/OpenPrinting/cups-filters/issues/569

----------

When pdftopdf moves all the Page option definitions into wrapping XObject, moving Transparency Group into XObject declaration prevents Ghostscript from detecting fake transparency (when the transparency is defined but not used), which slows the document rasterization.

Keep Transparency Group in Page declaration unless two or more pages with different transparency options are printed:
* **no `number-up`**: TG is in Page
* **`number-up=X`, same TGs in each page**: TG is in Page
* **`number-up=X`, different TGs**: fall back to TG in XObjects

See https://github.com/OpenPrinting/cups-filters/issues/569#issuecomment-3707820635 and https://bugs.ghostscript.com/show_bug.cgi?id=707523#c6 for more information.

### Test case

[price.pdf](https://github.com/OpenPrinting/cups-filters/files/14082059/price.pdf) file has `/S /Transparency` group defined for each page, pages 1-3 have fake transparency with only text, and only page 4 has a picture.

```sh
$ ./pdftopdf-original 1 1 1 1 'PageSize=A4 fitplot' price.pdf > price_original.pdf
$ ./pdftopdf-patched 1 1 1 1 'PageSize=A4 fitplot' price.pdf > price_patched.pdf

# Non-processed PDF file
$ time gs -dQUIET -dBATCH -dSAFER -dNOPAUSE -sDEVICE=cups -sOutputFile=%stdout -sstdout=%stderr -r600 -dDEVICEWIDTHPOINTS=595 -dDEVICEHEIGHTPOINTS=842 \
 -f price.pdf > /dev/null

INFO: Start rendering...
INFO: Processing page 1...
INFO: Processing page 2...
INFO: Processing page 3...
INFO: Processing page 4...
INFO: Processing page 5...
INFO: Rendering completed

real    0m0,362s
user    0m0,316s
sys     0m0,044s


# Processed with current pdftopdf code, Transparent Group is in each wrapper XObject
$ time gs -dQUIET -dBATCH -dSAFER -dNOPAUSE -sDEVICE=cups -sOutputFile=%stdout -sstdout=%stderr -r600 -dDEVICEWIDTHPOINTS=595 -dDEVICEHEIGHTPOINTS=842 \
 -f price_original.pdf > /dev/null

INFO: Start rendering...
INFO: Processing page 1...
INFO: Processing page 2...
INFO: Processing page 3...
INFO: Processing page 4...
INFO: Processing page 5...
INFO: Rendering completed

real    0m1,117s
user    0m1,036s
sys     0m0,076s


# Processed with patch, Transparent Group is in Page
$ time gs -dQUIET -dBATCH -dSAFER -dNOPAUSE -sDEVICE=cups -sOutputFile=%stdout -sstdout=%stderr -r600 -dDEVICEWIDTHPOINTS=595 -dDEVICEHEIGHTPOINTS=842 \
 -f price_patched.pdf > /dev/null

INFO: Start rendering...
INFO: Processing page 1...
INFO: Processing page 2...
INFO: Processing page 3...
INFO: Processing page 4...
INFO: Processing page 5...
INFO: Rendering completed

real    0m0,340s
user    0m0,306s
sys     0m0,032s

```

I've tested the patch accross my small collection of PDF files, and special transparency testing files ([here](https://github.com/OpenPrinting/libcupsfilters/issues/113) and also [this one](https://eci.org/lib/exe/eci_altona-test-suite-v2_technical2_one-patch-per-page_x4.pdf)), and all of them produce identical byte-to-byte rasterization result with and without the patch.
However I'm not versed in PDF at all, that's why think of this MR as a draft proposal, it need some additional validation that this approach is correct in all cases.