### PR TITLE
Fix build with CUPS 3.x

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -318,6 +318,9 @@ testfilters_LDADD = \
 	libcupsfilters.la \
 	$(CUPS_LIBS) \
 	-lm -ldl
+testfilters_CFLAGS = \
+	-I$(srcdir)/cupsfilters/ \
+	$(CUPS_CFLAGS)
 testfilters_LDFLAGS = \
 	-D_GNU_SOURCE \
 	-L/usr/lib

--- a/cupsfilters/catalog.h
+++ b/cupsfilters/catalog.h
@@ -69,7 +69,6 @@ extern "C" {
 #endif // WIN32 || __EMX__
 
 #include <cups/cups.h>
-#include <cups/backend.h>
 #include <cups/raster.h>
 
 // Data structure for IPP choice name and human-readable string

--- a/cupsfilters/ipp-options-private.h
+++ b/cupsfilters/ipp-options-private.h
@@ -56,6 +56,7 @@ struct _cups_array_s                    // CUPS array structure
   cups_afree_cb_t       freefunc;       // Free function
 };
 
+#if CUPS_VERSION_MAJOR < 3 && !(CUPS_VERSION_MAJOR == 2 && CUPS_VERSION_MINOR == 5)
 typedef struct cups_media_s             // Media information
 {
   char          media[128],             // Media name to use
@@ -69,6 +70,7 @@ typedef struct cups_media_s             // Media information
                 right,                  // Right margin in hundredths of millimeters
                 top;                    // Top margin in hundredths of millimeters
 } cups_media_t;
+#endif
 
 typedef enum cf_filter_delivery_e	// "page-delivery" values
 {

--- a/cupsfilters/ipp.c
+++ b/cupsfilters/ipp.c
@@ -27,7 +27,6 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <cups/cups.h>
-#include <cups/backend.h>
 #include <cups/dir.h>
 #include <cups/http.h>
 #include <cups/pwg.h>
@@ -1574,7 +1573,7 @@ cfGetPageDimensions(ipp_t *printer_attrs,   // I - Printer attributes
 	// String is a dictionary -> "media-col" value...
 	//
 
-	num_media_col = cupsParseOptions(value, 0, &media_col);
+	num_media_col = cupsParseOptions(value, NULL, 0, &media_col);
 
 	// Actual size in dictionary?
 	if ((value = cupsGetOption("media-size", num_media_col, media_col))
@@ -1585,7 +1584,7 @@ cfGetPageDimensions(ipp_t *printer_attrs,   // I - Printer attributes
 	  const char	*x_dimension,	// x-dimension value
 	                *y_dimension;	// y-dimension value
 
-	  num_media_size = cupsParseOptions(value, 0, &media_size);
+	  num_media_size = cupsParseOptions(value, NULL, 0, &media_size);
 
 	  if ((x_dimension = cupsGetOption("x-dimension", num_media_size, media_size)) != NULL && (y_dimension = cupsGetOption("y-dimension", num_media_size, media_size)) != NULL)
 	  {

--- a/cupsfilters/libcups2-private.h
+++ b/cupsfilters/libcups2-private.h
@@ -40,6 +40,10 @@
 #    define ippGetFirstAttribute   ippFirstAttribute
 #    define ippGetNextAttribute    ippNextAttribute
 
+//   Function with additional parameter in libcups3
+
+#    define cupsParseOptions(arg, end, num_options, options) cupsParseOptions(arg, num_options, options)
+
 //   Function replaced by a different function in libcups3
 
 #    define cupsCreateTempFd(prefix,suffix,buffer,bufsize) cupsTempFd(buffer,bufsize)

--- a/cupsfilters/testfilters.c
+++ b/cupsfilters/testfilters.c
@@ -9,6 +9,15 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#  if CUPS_VERISON_MAJOR < 3 /* CUPS 2.x and older */
+/* Functions changed in libcups3 */
+#    define cupsArrayGetCount      cupsArrayCount
+#    define cupsArrayGetFirst      cupsArrayFirst
+#    define cupsArrayGetNext       cupsArrayNext
+#    define cupsArrayNew           cupsArrayNew3
+#    define cupsParseOptions(arg, end, num_options, options) cupsParseOptions(arg, num_options, options)
+#endif
+
 /*
  * 'remove_white_space()' - Remove white spaces from beginning and end of a string
  */
@@ -73,7 +82,7 @@ cups_array_t*
 parse_filter_chain(const char *filter_chain_str, 
 		   const char *output_mime) 
 {
-  cups_array_t *chain = cupsArrayNew(NULL, NULL);
+  cups_array_t *chain = cupsArrayNew(NULL, NULL, NULL, 0, NULL, NULL);
   char *saveptr;
   char *filter_name = strtok_r((char *)filter_chain_str, ",", &saveptr);
   while (filter_name) 
@@ -279,7 +288,7 @@ test_wrapper(
 
   options = NULL;
   if (num_clargs > 5)
-    num_options = cupsParseOptions(clargs[5], 0, &options);
+    num_options = cupsParseOptions(clargs[5], NULL, 0, &options);
 	fprintf(stderr, "NUM Options: %d\n", num_options);
   if ((filter_data.printer = getenv("PRINTER")) == NULL)
     filter_data.printer = clargs[0];
@@ -347,10 +356,10 @@ test_wrapper(
 
 //  retval = cfFilterUniversal(inputfd, outputfd, inputseekable, &filter_data, parameters);
 
-   if (filter_chain && cupsArrayCount(filter_chain) > 0) {  
+   if (filter_chain && cupsArrayGetCount(filter_chain) > 0) {  
         retval = cfFilterChain(inputfd, outputfd, inputseekable, &filter_data, filter_chain);
 	cf_filter_filter_in_chain_t *filter;
-        while ((filter = cupsArrayFirst(filter_chain)) != NULL) {  
+        while ((filter = cupsArrayGetFirst(filter_chain)) != NULL) {  
             free(filter->parameters);
             cupsArrayRemove(filter_chain, filter);
             free(filter);
@@ -981,7 +990,7 @@ load_legacy_attributes(
   snprintf(device_id, sizeof(device_id), "MFG:%s;MDL:%s;", make, model);
   ptr    = device_id + strlen(device_id);
   prefix = "CMD:";
-  for (format = (const char *)cupsArrayFirst(docformats); format; format = (const char *)cupsArrayNext(docformats))
+  for (format = (const char *)cupsArrayGetFirst(docformats); format; format = (const char *)cupsArrayGetNext(docformats))
   {
     if (!strcasecmp(format, "application/pdf"))
       snprintf(ptr, sizeof(device_id) - (size_t)(ptr - device_id), "%sPDF", prefix);
@@ -1131,7 +1140,7 @@ run_test(
   int duplex = 0;
   int ppm_color = 0;
        
-  cups_array_t* docformats = cupsArrayNew(NULL, NULL);
+  cups_array_t* docformats = cupsArrayNew(NULL, NULL, NULL, 0, NULL, NULL);
     
   int jobCanceled = 0;
 


### PR DESCRIPTION
- Add additional changed function `cupsParseOptions()`
- Only define struct `cups_media_s` if running a version older then CUPS 2.5.
- Update `testfilters.c` to use CUPS 3.0 API with compatibility shim for CUPS 2.x and older. Given that this is an end-user program, we don't want to include `libcups2-private.h`.  Also tweaked Makefile to link against proper CUPS library.
- Removed unused reference to `cups/backend.h`.

Fixes #152