### PR TITLE
 Fix CUPS_VERSION_MAJOR typo and add CUPS_CFLAGS for libcups3 builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,6 +246,8 @@ testcmyk_SOURCES = \
 testcmyk_LDADD = \
 	libcupsfilters.la \
 	-lm
+testcmyk_CFLAGS = \
+	$(CUPS_CFLAGS)
 
 testdither_SOURCES = \
 	cupsfilters/testdither.c \
@@ -253,6 +255,8 @@ testdither_SOURCES = \
 testdither_LDADD = \
 	libcupsfilters.la \
 	-lm
+testdither_CFLAGS = \
+	$(CUPS_CFLAGS)
 
 testimage_SOURCES = \
 	cupsfilters/testimage.c \
@@ -266,7 +270,8 @@ testimage_LDADD = \
 testimage_CFLAGS = \
 	$(LIBJPEG_CFLAGS) \
 	$(LIBPNG_CFLAGS) \
-	$(TIFF_CFLAGS)
+	$(TIFF_CFLAGS) \
+	$(CUPS_CFLAGS)
 
 testrgb_SOURCES = \
 	cupsfilters/testrgb.c \
@@ -274,6 +279,8 @@ testrgb_SOURCES = \
 testrgb_LDADD = \
 	libcupsfilters.la \
 	-lm
+testrgb_CFLAGS = \
+	$(CUPS_CFLAGS)
 
 test1284_SOURCES = \
 	cupsfilters/test1284.c
@@ -289,7 +296,8 @@ testpdf1_SOURCES = \
 	cupsfilters/fontembed-private.h
 testpdf1_CFLAGS = \
 	-I$(srcdir)/cupsfilters/fontembed/ \
-	-I$(srcdir)/cupsfilters/
+	-I$(srcdir)/cupsfilters/ \
+	$(CUPS_CFLAGS)
 testpdf1_LDADD = \
 	libcupsfilters.la
 
@@ -298,18 +306,22 @@ testpdf2_SOURCES = \
 	cupsfilters/fontembed-private.h
 testpdf2_CFLAGS = \
 	-I$(srcdir)/cupsfilters/fontembed/ \
-	-I$(srcdir)/cupsfilters/
+	-I$(srcdir)/cupsfilters/ \
+	$(CUPS_CFLAGS)
 testpdf2_LDADD = \
 	libcupsfilters.la
 
 test_analyze_SOURCES = cupsfilters/fontembed/test-analyze.c
 test_analyze_LDADD = libcupsfilters.la
+test_analyze_CFLAGS = $(CUPS_CFLAGS)
 
 test_pdf_SOURCES = cupsfilters/fontembed/test-pdf.c
 test_pdf_LDADD = libcupsfilters.la
+test_pdf_CFLAGS = $(CUPS_CFLAGS)
 
 test_ps_SOURCES = cupsfilters/fontembed/test-ps.c
 test_ps_LDADD = libcupsfilters.la
+test_ps_CFLAGS = $(CUPS_CFLAGS)
 
 testfilters_SOURCES = \
 	cupsfilters/testfilters.c \

--- a/cupsfilters/testfilters.c
+++ b/cupsfilters/testfilters.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#  if CUPS_VERISON_MAJOR < 3 /* CUPS 2.x and older */
+#  if CUPS_VERSION_MAJOR < 3 /* CUPS 2.x and older */
 /* Functions changed in libcups3 */
 #    define cupsArrayGetCount      cupsArrayCount
 #    define cupsArrayGetFirst      cupsArrayFirst

--- a/libcupsfilters.pc.in
+++ b/libcupsfilters.pc.in
@@ -9,4 +9,4 @@ Version: @VERSION@
 
 Libs: -L${libdir} -lcupsfilters
 Libs.private: @CUPS_LIBS@ @LIBJPEG_LIBS@ @LIBPNG_LIBS@ @LIBTIFF_LIBS@ @LIBPDFIO_LIBS@
-Cflags: -I${includedir}/cupsfilters -I${includedir}
+Cflags: -I${includedir}/cupsfilters -I${includedir} @CUPS_CFLAGS@


### PR DESCRIPTION
## Summary

  Three small, self-contained build fixes needed to compile cleanly against
  libcups3 (CUPS 3.x), where the CUPS headers live off the default include
  path and are only found via `CUPS_CFLAGS`. None of these change runtime
  behaviour; they only correct the build.

  ## Changes

  1. **`cupsfilters/testfilters.c` — fix `CUPS_VERISON_MAJOR` typo**
     The macro name was misspelled, so the preprocessor treated it as `0`.
     That made `#if CUPS_VERISON_MAJOR < 3` always true, forcing the libcups2
     compatibility `#define`s onto a libcups3 build and breaking it. Corrected
     to `CUPS_VERSION_MAJOR`.

  2. **`Makefile.am` — add `$(CUPS_CFLAGS)` to the test programs**
     `testcmyk`, `testdither`, `testimage`, `testrgb`, `testpdf1`, `testpdf2`,
     `test-analyze`, `test-pdf` and `test-ps` include libcupsfilters headers
     that pull in `<cups/cups.h>`. Without `$(CUPS_CFLAGS)` they fail to find
     the CUPS headers under libcups3 (`cups/cups.h: No such file or directory`).
     `test1284` and `testfilters` already passed `$(CUPS_CFLAGS)`; this brings
     the rest in line.

  3. **`libcupsfilters.pc.in` — add `@CUPS_CFLAGS@` to `Cflags`**
     The installed public headers `#include <cups/cups.h>`, so a downstream
     consumer compiling against `pkg-config --cflags libcupsfilters` also needs
     the CUPS include path. Without it, consumer builds break against libcups3.
