### PR TITLE
Fix printing error:  pdfio output "Missing Root object."

### DIFF
--- a/cupsfilters/pdf.c
+++ b/cupsfilters/pdf.c
@@ -165,6 +165,11 @@ cfPDFPagesFP(FILE *file) 	// I - File pointer of PDF
     fwrite(buffer, 1, bytes_read, temp_fp);
   }
 
+  // call fflush(temp_fp) to flush the stdio buffer; 
+  // otherwise pdfioFileOpen() may not see the complete contents of temp_filename because 
+  // some data may still be buffered and not yet written to the file.
+  fflush(temp_fp);  
+
   // Open the temp file with pdfio
   pdfio_file_t *pdf = pdfioFileOpen(temp_filename, NULL, NULL, NULL, NULL);
 


### PR DESCRIPTION
After compiling and printing using the master branch code, the print job fails. The error log indicates that the temporary PDF file generated is structurally incomplete. As a result, the gstoraster filter reports an unexpected page count and terminates with an error.
```
D [14/Jul/2026:09:05:44 +0800] [Job 625] /tmp/pdf-file-uIhiV5: WARNING: Unable to find start of cross-reference table, will attempt to rebuild.					
D [14/Jul/2026:09:05:44 +0800] [Job 625] /tmp/pdf-file-uIhiV5: Missing value for dictionary key \'CapHe\'.					
D [14/Jul/2026:09:05:44 +0800] [Job 625] /tmp/pdf-file-uIhiV5: WARNING: Unable to read object dictionary/value.					
D [14/Jul/2026:09:05:44 +0800] [Job 625] /tmp/pdf-file-uIhiV5: Missing Root object.					
E [14/Jul/2026:09:05:44 +0800] [Job 625] cfFilterGhostscript: Unexpected page count					
D [14/Jul/2026:09:05:44 +0800] [Job 625] Set job-printer-state-message to "cfFilterGhostscript: Unexpected page count", current level=ERROR					
E [14/Jul/2026:09:05:44 +0800] [Job 625] gstoraster filter failed.					
D [14/Jul/2026:09:05:44 +0800] [Job 625] PID 4105 (/usr/lib/cups/filter/pdftopdf) exited with no errors.					
D [14/Jul/2026:09:05:44 +0800] [Job 625] PID 4106 (/usr/lib/cups/filter/gstoraster) stopped with status 1.			
```

The root cause is that when pdfioFileOpen() attempts to read temp_filename, some of the data previously written to temp_fp is still buffered in the stdio layer and has not yet been flushed to disk. This causes pdfio to read an incomplete PDF file.

The fix is to call fflush(temp_fp) before invoking pdfioFileOpen(). This ensures that all buffered data is written to the file so that pdfio can read a complete and structurally valid PDF document.