### PR TITLE
Remove CXX  and poppler-cpp build requires

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,10 +214,6 @@ libcupsfilters_la_LIBADD = \
 	$(LIBPNG_LIBS) \
 	$(TIFF_LIBS) \
 	-lm
-if ENABLE_POPPLER
-libcupsfilters_la_LIBADD += \
-	$(POPPLER_LIBS)
-endif
 libcupsfilters_la_CFLAGS = \
 	-I$(srcdir)/cupsfilters/fontembed/ \
 	$(FONTCONFIG_CFLAGS) \
@@ -235,7 +231,6 @@ libcupsfilters_la_LDFLAGS = \
 	$(LIBJXL_LIBS)
 if BUILD_DBUS
 libcupsfilters_la_CFLAGS += $(DBUS_CFLAGS) -DHAVE_DBUS
-libcupsfilters_la_CXXFLAGS = -std=c++11 $(libcupsfilters_la_CFLAGS)   # -std=c++11
 libcupsfilters_la_LIBADD += $(DBUS_LIBS)
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ m4_include([m4/ax_compare_version.m4])
 m4_include([m4/basic-directories.m4])
 AM_INIT_AUTOMAKE([1.11 gnu dist-xz dist-bzip2 subdir-objects foreign])
 AM_SILENT_RULES([yes])
-AC_LANG([C++])
+AC_LANG([C])
 AC_CONFIG_HEADERS([config.h])
 # Extra defines for the config.h
 AH_BOTTOM([
@@ -50,11 +50,8 @@ AH_BOTTOM([
 # Find required base packages
 # ===========================
 AC_PROG_CC
-AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 AM_PROG_CC_C_O
 AM_ICONV
-AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
@@ -566,10 +563,8 @@ AS_IF([test x"$enable_werror" = "xyes"], [
 AS_IF([test x"$GCC" = "xyes"], [
 	# Be tough with warnings and produce less careless code
 	CFLAGS="$CFLAGS -Wall -std=gnu11"
-	CXXFLAGS="$CXXFLAGS -Wall " # -Weffc++" # TODO: enable when it does not print 1MB of warnings
 ])
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
-CXXFLAGS="$CXXFLAGS -std=c++17"
 
 # =========
 # CJK FONTS
@@ -601,7 +596,6 @@ AC_MSG_NOTICE([
 ==============================================================================
 Environment settings:
 	CFLAGS:                                    ${CFLAGS}
-	CXXFLAGS:                                  ${CXXFLAGS}
 	LDFLAGS:                                   ${LDFLAGS}
 Build configuration:
         libcups:         ${CUPS_VERSION}

--- a/configure.ac
+++ b/configure.ac
@@ -373,18 +373,6 @@ AS_IF([test x"$with_fontconfig" != "xno" && test "x$enable_texttopdf" != "xno"],
 PKG_CHECK_MODULES([LIBPDFIO], [pdfio >= 1.6.4])
 
 
-# =================
-# Check for Poppler
-# =================
-AC_ARG_ENABLE(poppler, AS_HELP_STRING([--enable-poppler],[enable Poppler-based filters]),
-	      enable_poppler=$enableval,enable_poppler=yes)
-AM_CONDITIONAL([ENABLE_POPPLER], test x$enable_poppler = xyes)
-if test x$enable_poppler = xyes; then
-	PKG_CHECK_MODULES([POPPLER], [poppler-cpp >= 0.19])
-	AC_CHECK_HEADER([poppler/cpp/poppler-version.h], [AC_DEFINE([HAVE_CPP_POPPLER_VERSION_H],[1],[Define if you have Poppler's "cpp/poppler-version.h" header file.])], [])
-	AC_DEFINE([HAVE_POPPLER], [1], [Define that we provide Poppler library])
-fi
-
 # ===============
 # Check for D-Bus
 # ===============

--- a/cupsfilters/universal.c
+++ b/cupsfilters/universal.c
@@ -270,7 +270,7 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
 		     "cfFilterUniversal: Adding %s to chain", filter->name);
       }
 
-#if defined(HAVE_GHOSTSCRIPT) || defined(HAVE_POPPLER)
+#if defined(HAVE_GHOSTSCRIPT)
       if (strcasecmp(output_type, "vnd.cups-pdf"))
       {
 	if (!strcasecmp(output_type, "vnd.cups-raster") ||
@@ -296,7 +296,6 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
 		       "cfFilterUniversal: Adding %s to chain",
 		       filter->name);
 #  else
-#    ifdef HAVE_POPPLER
 	  filter = malloc(sizeof(cf_filter_filter_in_chain_t));
 	  filter->function = cfFilterPDFToRaster;
 	  filter->parameters = NULL;
@@ -317,19 +316,18 @@ cfFilterUniversal(int inputfd,		// I - File descriptor input stream
 	    if (log) log(ld, CF_LOGLEVEL_DEBUG,
 			 "cfFilterUniversal: Adding %s to chain", filter->name);
 	  }
-#    endif // HAVE_POPPLER
 #  endif // HAVE_GHOSTSCRIPT
 	}
 	else
 	{
-#endif // HAVE_GHOSTSCRIPT || HAVE_POPPLER
+#endif // HAVE_GHOSTSCRIPT
 	  // Output format is not PDF and unknown -> Error
 	  ret = 1;
 	  goto out;
-#if defined(HAVE_GHOSTSCRIPT) || defined(HAVE_POPPLER)
+#if defined(HAVE_GHOSTSCRIPT)
 	}
       }
-#endif // HAVE_GHOSTSCRIPT || HAVE_POPPLER
+#endif // HAVE_GHOSTSCRIPT
     }
   }
 


### PR DESCRIPTION
IIUC both are now unneeded, because pdftoraster is now for pdfio, and after dropping qpdf support no C++ code is present.