### PR TITLE
Makefile.am: Ensure gen-lorem-text test supports out of tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -348,6 +348,7 @@ BUILT_SOURCES = cupsfilters/test_files/test_text_lorem.txt
 CLEANFILES   = cupsfilters/test_files/test_text_lorem.txt
 
 cupsfilters/test_files/test_text_lorem.txt: gen-lorem-text
+	$(MKDIR_P) $(@D)
 	$(AM_V_GEN)./gen-lorem-text > $@
 
 EXTRA_DIST += \


### PR DESCRIPTION
For out of tree builds, the target directory needs to exist for the generator to write the file to, fixes:

```
./gen-lorem-text > cupsfilters/test_files/test_text_lorem.txt
/bin/sh: line 1: cupsfilters/test_files/test_text_lorem.txt: No such file or directory
```

This issue was introduced in https://github.com/OpenPrinting/libcupsfilters/pull/119

Discovered during the upgrade to 2.2.0 in the freedesktop-sdk project:

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/33665