### PR TITLE
Cap PNG dimensions to avoid memory exhaustion (OCU-01-016)

### DIFF
--- a/cupsfilters/image-png.c
+++ b/cupsfilters/image-png.c
@@ -165,7 +165,8 @@ _cfImageReadPNG(
     img->colorspace = secondary;
 
   if (width == 0 || width > CF_IMAGE_MAX_WIDTH ||
-      height == 0 || height > CF_IMAGE_MAX_HEIGHT)
+      height == 0 || height > CF_IMAGE_MAX_HEIGHT ||
+      width > CF_IMAGE_MAX_PIXELS || height > CF_IMAGE_MAX_PIXELS)
   {
     DEBUG_printf(("DEBUG: PNG image has invalid dimensions %ux%u!\n",
 		  (unsigned)width, (unsigned)height));

--- a/cupsfilters/image-private.h
+++ b/cupsfilters/image-private.h
@@ -52,6 +52,14 @@
 #  define CF_IMAGE_MAX_HEIGHT	0x3fffffff
 					// 2^30-1
 
+#  define CF_IMAGE_MAX_PIXELS	283465
+					// Max pixels per side: 5 m at 1440 dpi,
+					// the largest realistic print (5 m-wide
+					// inkjets exist). Bounding each dimension
+					// keeps the decoded buffer-size
+					// multiplication from overflowing;
+					// allocations too large for the machine
+					// then fail gracefully at malloc().
 #  define CF_TILE_SIZE		256	// 256x256 pixel tiles
 #  define CF_TILE_MINIMUM	10	// Minimum number of tiles
 


### PR DESCRIPTION
### What this fixes

Fixes #215  (audit finding OCU-01-016).

`_cfImageReadPNG()` loads interlaced PNGs all at once, allocating `xsize * ysize * 3` in a single `malloc`. The existing checks only catch integer overflow of that multiplication, not large-but-valid sizes, so a crafted interlaced PNG with huge dimensions can request an enormous allocation from a small compressed file and exhaust memory in the filter child. It's reachable through the normal PNG print path.

### The changes

- Added `CF_IMAGE_MAX_PIXELS` (283465), the pixels-per-side for a 5m print at 1440 dpi, which covers the largest realistic print (5m-wide inkjets exist).
- `_cfImageReadPNG()` now rejects images whose width or height exceeds that.

Bounding each dimension keeps the decoded-size multiplication from overflowing. Any allocation still too large for the machine then fails gracefully at the existing `malloc` NULL check, so real PNGs keep printing and only unreasonable input is rejected.