### PR TITLE
libcupsfilters.pc: Add pdfio as public Requires dependency

### DIFF
--- a/libcupsfilters.pc.in
+++ b/libcupsfilters.pc.in
@@ -2,11 +2,12 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-                                                                       
+
 Name: libcupsfilters
 Description: Library providing everything for filtering/converting print/scan job data
 Version: @VERSION@
 
+Requires: pdfio >= 1.6.4
 Libs: -L${libdir} -lcupsfilters
-Libs.private: @CUPS_LIBS@ @LIBJPEG_LIBS@ @LIBPNG_LIBS@ @LIBTIFF_LIBS@ @LIBPDFIO_LIBS@
+Libs.private: @CUPS_LIBS@ @LIBJPEG_LIBS@ @LIBPNG_LIBS@ @LIBTIFF_LIBS@
 Cflags: -I${includedir}/cupsfilters -I${includedir} @CUPS_CFLAGS@


### PR DESCRIPTION
Fixes #213

pdf.h is a public installed header that includes <pdfio.h> directly:

    #include <pdfio.h>

This means downstream packages (e.g. libppd) that include pdf.h need
pdfio headers and types at compile time. However, pdfio was only listed
in Libs.private, which pkg-config does not propagate to consumers.

Fix: add pdfio to Requires and remove it from Libs.private to avoid
double-linking.