### PR TITLE
ghostscript: serialize raster integer parameters as signed

### DIFF
--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -207,22 +207,22 @@ header_to_gs_args(gs_page_header *h,
     }
     if (h->AdvanceDistance)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dAdvanceDistance=%u",
-	       (unsigned)(h->AdvanceDistance));
+      snprintf(tmpstr, sizeof(tmpstr), "-dAdvanceDistance=%d",
+	       (int)(h->AdvanceDistance));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->AdvanceMedia)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dAdvanceMedia=%u",
-	       (unsigned)(h->AdvanceMedia));
+      snprintf(tmpstr, sizeof(tmpstr), "-dAdvanceMedia=%d",
+	       (int)(h->AdvanceMedia));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->Collate)
       cupsArrayAdd(gs_args, strdup("-dCollate"));
     if (h->CutMedia)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dCutMedia=%u",
-	       (unsigned)(h->CutMedia));
+      snprintf(tmpstr, sizeof(tmpstr), "-dCutMedia=%d",
+	       (int)(h->CutMedia));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
   }
@@ -254,14 +254,14 @@ header_to_gs_args(gs_page_header *h,
       cupsArrayAdd(gs_args, strdup("-dInsertSheet"));
     if (h->Jog)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dJog=%u",
-	       (unsigned)(h->Jog));
+      snprintf(tmpstr, sizeof(tmpstr), "-dJog=%d",
+	       (int)(h->Jog));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->LeadingEdge)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dLeadingEdge=%u",
-	       (unsigned)(h->LeadingEdge));
+      snprintf(tmpstr, sizeof(tmpstr), "-dLeadingEdge=%d",
+	       (int)(h->LeadingEdge));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->ManualFeed)
@@ -309,8 +309,8 @@ header_to_gs_args(gs_page_header *h,
       }
       else
 	mediapos = h->MediaPosition;
-      snprintf(tmpstr, sizeof(tmpstr), "-dMediaPosition=%u",
-	       (unsigned)(mediapos));
+      snprintf(tmpstr, sizeof(tmpstr), "-dMediaPosition=%d",
+	       (int)(mediapos));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
   }
@@ -320,8 +320,8 @@ header_to_gs_args(gs_page_header *h,
   {
     if (h->MediaWeight)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dMediaWeight=%u",
-	       (unsigned)(h->MediaWeight));
+      snprintf(tmpstr, sizeof(tmpstr), "-dMediaWeight=%d",
+	       (int)(h->MediaWeight));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->MirrorPrint)
@@ -330,14 +330,14 @@ header_to_gs_args(gs_page_header *h,
       cupsArrayAdd(gs_args, strdup("-dNegativePrint"));
     if (h->NumCopies != 1)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dNumCopies=%u",
-	       (unsigned)(h->NumCopies));
+      snprintf(tmpstr, sizeof(tmpstr), "-dNumCopies=%d",
+	       (int)(h->NumCopies));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->Orientation)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dOrientation=%u",
-	       (unsigned)(h->Orientation));
+      snprintf(tmpstr, sizeof(tmpstr), "-dOrientation=%d",
+	       (int)(h->Orientation));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->OutputFaceUp)
@@ -376,8 +376,8 @@ header_to_gs_args(gs_page_header *h,
   {
     if (h->cupsMediaType)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dcupsMediaType=%u",
-	       (unsigned)(h->cupsMediaType));
+      snprintf(tmpstr, sizeof(tmpstr), "-dcupsMediaType=%d",
+	       (int)(h->cupsMediaType));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     snprintf(tmpstr, sizeof(tmpstr), "-dcupsBitsPerColor=%d",
@@ -412,26 +412,26 @@ header_to_gs_args(gs_page_header *h,
   {
     if (h->cupsCompression)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dcupsCompression=%u",
-	       (unsigned)(h->cupsCompression));
+      snprintf(tmpstr, sizeof(tmpstr), "-dcupsCompression=%d",
+	       (int)(h->cupsCompression));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->cupsRowCount)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowCount=%u",
-	       (unsigned)(h->cupsRowCount));
+      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowCount=%d",
+	       (int)(h->cupsRowCount));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->cupsRowFeed)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowFeed=%u",
-	       (unsigned)(h->cupsRowFeed));
+      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowFeed=%d",
+	       (int)(h->cupsRowFeed));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
     if (h->cupsRowStep)
     {
-      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowStep=%u",
-	       (unsigned)(h->cupsRowStep));
+      snprintf(tmpstr, sizeof(tmpstr), "-dcupsRowStep=%d",
+	       (int)(h->cupsRowStep));
       cupsArrayAdd(gs_args, strdup(tmpstr));
     }
   }
@@ -449,8 +449,8 @@ header_to_gs_args(gs_page_header *h,
     for (i = 0; i <= 15; i ++)
       if (h->cupsInteger[i])
       {
-	snprintf(tmpstr, sizeof(tmpstr), "-dcupsInteger%d=%u",
-		 i, (unsigned)(h->cupsInteger[i]));
+	snprintf(tmpstr, sizeof(tmpstr), "-dcupsInteger%d=%d",
+		 i, (int)(h->cupsInteger[i]));
 	cupsArrayAdd(gs_args, strdup(tmpstr));
       }
     for (i = 0; i <= 15; i ++)


### PR DESCRIPTION
  Fixes #218.
  Related to #222.

  ## Problem

  Commit b558b364 changed several Ghostscript CUPS raster parameters from
  signed (`%d`) to unsigned (`%u`) formatting.

  Some fields in `cups_page_header_t` are unsigned storage locations but
  legitimately contain the two's-complement representation of signed values.
  For example, label-printer PPDs use:

      <</cupsCompression -1>>setpagedevice

  With libcupsfilters 2.2.1 this is emitted as:

      -dcupsCompression=4294967295

  Ghostscript reads these device properties using its signed
  `param_read_int()` interface, rejects the value, and terminates with:

      Error setting cupsCompression
      Unrecoverable error: rangecheck in .putdeviceprops

  The same signedness problem affects `cupsInteger[]`, as demonstrated by
  issue #222.

  ## Fix

  Serialize CUPS raster integer fields using `%d` with an explicit `(int)`
  conversion. This preserves signed values while avoiding the original
  printf argument-type mismatch.

  ## Reproduction

  Environment:

  - Arch Linux x86_64
  - CUPS 2.4.19
  - cups-filters 2.0.1
  - libcupsfilters 2.2.1
  - libppd 2.1.1
  - Ghostscript 10.07.1
  - 4BARCODE 4B-2054K using the standard ZPL `rastertolabel` PPD

  Using the PPD default `Darkness=-1`:

  - Unpatched 2.2.1:
    - emits `-dcupsCompression=4294967295`
    - exits with status 1
    - produces 0 raster bytes
  - Patched 2.2.1:
    - emits `-dcupsCompression=-1`
    - exits with status 0
    - produces 500,340 raster bytes

  The test invokes the `universal` filter directly with the same PPD and
  input PDF, changing only the loaded libcupsfilters library.

  ## Testing

  - `make check`: 9 passed, 0 failed
  - Arch package built successfully
  - Direct unpatched/patched A/B rasterization test passed
  - Live printing through the patched package succeeded
 
[patched-2.2.1.log](https://github.com/user-attachments/files/31657415/patched-2.2.1.log)
[unpatched-2.2.1.log](https://github.com/user-attachments/files/31657416/unpatched-2.2.1.log)
