### PR TITLE
Honor data->copies in cfFilterPDFToPDF (fix multi-copy printing for raster drivers)

### DIFF
--- a/cupsfilters/pdftopdf.c
+++ b/cupsfilters/pdftopdf.c
@@ -2777,6 +2777,16 @@ cfFilterPDFToPDF(int inputfd,
 
   filter_options = cfFilterOptionsCreate(data->num_options, data->options);
 
+  // CUPS passes the copy count through the standard "copies" filter argument
+  // (argv[4], exposed here as data->copies) and strips the "copies" option
+  // from the options string (argv[5]).  cfFilterOptionsCreate() only reads
+  // the copy count from the options string, so it defaults to 1 and the
+  // requested number of copies is lost.  Honor data->copies as a fallback so
+  // that printing multiple copies works for raster drivers going through the
+  // "universal" filter.
+  if (data->copies > 1 && filter_options->copies <= 1)
+    filter_options->copies = data->copies;
+
   char temp_filename[] = "/tmp/tempfileXXXXXX";
   int temp_fd = mkstemp(temp_filename);
   if (temp_fd == -1)


### PR DESCRIPTION
## Problem

Printing multiple copies ("print N copies") to a CUPS **raster** printer whose PPD uses a `*cupsFilter:` line (routed through the cups-filters `universal` filter) always prints exactly **1 copy**.

Fixes: https://github.com/OpenPrinting/libcupsfilters/issues/227

## Root cause

1. CUPS passes the requested copy count to filters via the standard `copies` argument (`argv[4]`, exposed as `data->copies`) and **strips the `copies` option from the options string (`argv[5]`)**.
2. `cfFilterOptionsCreate()` (in `ipp-options.c`) only reads the copy count from the options string and defaults `ippo->copies` to `1`. It never consults `data->copies`.
3. `cfFilterPDFToPDF()` builds its options with `cfFilterOptionsCreate(data->num_options, data->options)` and therefore never sees the requested copy count, so it always generates a single copy.

## Fix

Honor `data->copies` as a fallback when no explicit `copies` option was supplied:

```c
if (data->copies > 1 && filter_options->copies <= 1)
  filter_options->copies = data->copies;
```

## Verification

Tested on an Epson L120 Series (raster driver via `universal` filter), CUPS 2.4.19, cups-filters 2.0.1 / libcupsfilters 2.2.1:

- Before: `lp -d <printer> -n 3 file` prints 1 sheet.
- After: prints 3 sheets.

The resulting CUPS raster stream is exactly N × the size of a single-copy run (verified 1, 2, and 3 copies).